### PR TITLE
Fu huang hou

### DIFF
--- a/src/core/characters/yijiang2013/fuhuanghou.ts
+++ b/src/core/characters/yijiang2013/fuhuanghou.ts
@@ -1,5 +1,6 @@
 import { GameCharacterExtensions } from 'core/game/game_props';
 import { SkillLoader } from 'core/game/package_loader/loader.skills';
+import { QiuYuan, ZhuiKong } from 'core/skills';
 import { Character, CharacterGender, CharacterNationality } from '../character';
 
 const skillLoader = SkillLoader.getInstance();
@@ -14,7 +15,7 @@ export class FuHuangHou extends Character {
       3,
       3,
       GameCharacterExtensions.YiJiang2013,
-      [...skillLoader.getSkillsByName('zhuikong'), skillLoader.getSkillByName('qiuyuan')],
+      [...skillLoader.getSkillsByName(ZhuiKong.Name), skillLoader.getSkillByName(QiuYuan.Name)],
     );
   }
 }

--- a/src/core/characters/yijiang2013/fuhuanghou.ts
+++ b/src/core/characters/yijiang2013/fuhuanghou.ts
@@ -1,0 +1,20 @@
+import { GameCharacterExtensions } from 'core/game/game_props';
+import { SkillLoader } from 'core/game/package_loader/loader.skills';
+import { Character, CharacterGender, CharacterNationality } from '../character';
+
+const skillLoader = SkillLoader.getInstance();
+
+export class FuHuangHou extends Character {
+  constructor(id: number) {
+    super(
+      id,
+      'fuhuanghou',
+      CharacterGender.Female,
+      CharacterNationality.Qun,
+      3,
+      3,
+      GameCharacterExtensions.YiJiang2013,
+      [...skillLoader.getSkillsByName('zhuikong'), skillLoader.getSkillByName('qiuyuan')],
+    );
+  }
+}

--- a/src/core/characters/yijiang2013/index.ts
+++ b/src/core/characters/yijiang2013/index.ts
@@ -1,5 +1,6 @@
 import { Character } from '../character';
 import { CaoChong } from './caochong';
+import { FuHuangHou } from './fuhuanghou';
 import { GuanPing } from './guanping';
 import { GuoHuai } from './guohuai';
 import { JianYong } from './jianyong';
@@ -12,8 +13,8 @@ import { ZhuRan } from './zhuran';
 
 export const YiJiang2013Package: (index: number) => Character[] = index => [
   new CaoChong(index++),
-  // new FuHuangHou(index++),
   new GuanPing(index++),
+  new FuHuangHou(index++),
   new GuoHuai(index++),
   new LiRu(index++),
   new JianYong(index++),

--- a/src/core/game/game_processor/game_processor.standard.ts
+++ b/src/core/game/game_processor/game_processor.standard.ts
@@ -1692,8 +1692,7 @@ export class StandardGameProcessor extends GameProcessor {
 
       if (!event.translationsMessage && to) {
         if (toArea === PlayerCardsArea.HandArea) {
-          const isPrivateCardMoving = !!movingCards.find(({ fromArea }) => fromArea === CardMoveArea.HandArea);
-          if (isPrivateCardMoving) {
+          if (!event.engagedPlayerIds) {
             event.engagedPlayerIds = [];
             fromId && event.engagedPlayerIds.push(fromId);
             toId && event.engagedPlayerIds.push(toId);

--- a/src/core/player/player.ts
+++ b/src/core/player/player.ts
@@ -544,7 +544,7 @@ export abstract class Player implements PlayerInfo {
         return skills.filter(skill => skill instanceof RulesBreakerSkill) as T[];
       case 'globalBreaker':
         return skills.filter(skill => skill instanceof GlobalRulesBreakerSkill) as T[];
-      case 'complusory':
+      case 'compulsory':
         return skills.filter(skill => skill.SkillType === SkillType.Compulsory) as T[];
       case 'awaken':
         return skills.filter(skill => skill.SkillType === SkillType.Awaken) as T[];

--- a/src/core/player/player.ts
+++ b/src/core/player/player.ts
@@ -22,6 +22,7 @@ import {
   ActiveSkill,
   FilterSkill,
   GlobalFilterSkill,
+  GlobalRulesBreakerSkill,
   RulesBreakerSkill,
   Skill,
   SkillType,
@@ -41,6 +42,7 @@ type SkillStringType =
   | 'filter'
   | 'globalFilter'
   | 'breaker'
+  | 'globalBreaker'
   | 'transform'
   | 'viewAs';
 
@@ -370,6 +372,14 @@ export abstract class Player implements PlayerInfo {
   public canUseCardTo(room: Room, cardId: CardId | CardMatcher, target: PlayerId): boolean {
     const player = room.getPlayerById(target);
 
+    for (const skillOwner of room.getAlivePlayersFrom()) {
+      for (const skill of skillOwner.getSkills<GlobalFilterSkill>('globalFilter')) {
+        if (!skill.canUseCardTo(cardId, room, skillOwner, this, room.getPlayerById(target))) {
+          return false;
+        }
+      }
+    }
+
     for (const skill of player.getSkills<FilterSkill>('filter')) {
       if (!skill.canBeUsedCard(cardId, room, target, this.Id)) {
         return false;
@@ -532,7 +542,9 @@ export abstract class Player implements PlayerInfo {
         return skills.filter(skill => skill instanceof TriggerSkill) as T[];
       case 'breaker':
         return skills.filter(skill => skill instanceof RulesBreakerSkill) as T[];
-      case 'compulsory':
+      case 'globalBreaker':
+        return skills.filter(skill => skill instanceof GlobalRulesBreakerSkill) as T[];
+      case 'complusory':
         return skills.filter(skill => skill.SkillType === SkillType.Compulsory) as T[];
       case 'awaken':
         return skills.filter(skill => skill.SkillType === SkillType.Awaken) as T[];
@@ -573,6 +585,8 @@ export abstract class Player implements PlayerInfo {
         return skills.filter(skill => skill instanceof TriggerSkill) as T[];
       case 'breaker':
         return skills.filter(skill => skill instanceof RulesBreakerSkill) as T[];
+      case 'globalBreaker':
+        return skills.filter(skill => skill instanceof GlobalRulesBreakerSkill) as T[];
       case 'transform':
         return skills.filter(skill => skill instanceof TransformSkill) as T[];
       case 'compulsory':

--- a/src/core/room/room.server.ts
+++ b/src/core/room/room.server.ts
@@ -873,11 +873,23 @@ export class ServerRoom extends Room<WorkPlace.Server> {
         let nullifiedTargets: PlayerId[] = event.nullifiedTargets || [];
 
         if (toIds) {
+          // need to refactor it
+          let currentLength = toIds.length;
+          //
           for (const toId of toIds) {
             const response = await this.onAim(event, toId, toIds, nullifiedTargets, toId === toIds[0]);
+            // need to refactor it
+            while (toIds.length < response.allTargets.length) {
+              involvedPlayerIds?.push([response.allTargets[currentLength]]);
+              currentLength++;
+            }
+            //
             aimEventCollaborators[toId] = response;
             nullifiedTargets = response.nullifiedTargets;
           }
+          // need to refactor it
+          this.sortByPlayersPosition(involvedPlayerIds!, ids => this.getPlayerById(ids[0]));
+          //
         }
 
         if (card.is(CardType.Equip)) {

--- a/src/core/room/room.server.ts
+++ b/src/core/room/room.server.ts
@@ -867,27 +867,23 @@ export class ServerRoom extends Room<WorkPlace.Server> {
       if (stage === CardUseStage.AfterCardUseEffect) {
         const card = Sanguosha.getCardById(event.cardId);
         const aimEventCollaborators: { [player: string]: ServerEventFinder<GameEventIdentifiers.AimEvent> } = {};
-        const involvedPlayerIds = TargetGroupUtil.getAllTargets(event.targetGroup);
+        let involvedPlayerIds = TargetGroupUtil.getAllTargets(event.targetGroup);
         involvedPlayerIds && this.sortByPlayersPosition(involvedPlayerIds, ids => this.getPlayerById(ids[0]));
         const toIds = involvedPlayerIds?.map(ids => ids[0]);
         let nullifiedTargets: PlayerId[] = event.nullifiedTargets || [];
 
         if (toIds) {
-          // need to refactor it
-          let currentLength = toIds.length;
-          //
+          let allTargets: PlayerId[] = [];
           for (const toId of toIds) {
             const response = await this.onAim(event, toId, toIds, nullifiedTargets, toId === toIds[0]);
-            // need to refactor it
-            while (toIds.length < response.allTargets.length) {
-              involvedPlayerIds?.push([response.allTargets[currentLength]]);
-              currentLength++;
-            }
-            //
             aimEventCollaborators[toId] = response;
             nullifiedTargets = response.nullifiedTargets;
+
+            allTargets = response.allTargets;
           }
           // need to refactor it
+          involvedPlayerIds = involvedPlayerIds?.filter(ids => allTargets.includes(ids[0]));
+          allTargets.forEach(id => !toIds.includes(id) && involvedPlayerIds!.push([id]));
           this.sortByPlayersPosition(involvedPlayerIds!, ids => this.getPlayerById(ids[0]));
           //
         }

--- a/src/core/room/room.ts
+++ b/src/core/room/room.ts
@@ -25,7 +25,7 @@ import { Precondition } from 'core/shares/libs/precondition/precondition';
 import { System } from 'core/shares/libs/system';
 import { GameMode } from 'core/shares/types/room_props';
 import { RoomInfo } from 'core/shares/types/server_types';
-import { FilterSkill, RulesBreakerSkill, TransformSkill } from 'core/skills/skill';
+import { FilterSkill, GlobalRulesBreakerSkill, RulesBreakerSkill, TransformSkill } from 'core/skills/skill';
 import { PatchedTranslationObject } from 'core/translations/translation_json_tool';
 
 export type RoomId = number;
@@ -450,6 +450,15 @@ export abstract class Room<T extends WorkPlace = WorkPlace> {
       return 0;
     }
 
+    for (const player of this.getAlivePlayersFrom()) {
+      for (const skill of player.getPlayerSkills<GlobalRulesBreakerSkill>('globalBreaker')) {
+        const breakDistance = skill.breakDistance(this, player, from, to);
+        if (breakDistance > 0) {
+          return breakDistance;
+        }
+      }
+    }
+
     for (const skill of from.getPlayerSkills<RulesBreakerSkill>('breaker')) {
       const breakDistance = skill.breakDistanceTo(this, from, to);
       if (breakDistance > 0) {
@@ -460,6 +469,7 @@ export abstract class Room<T extends WorkPlace = WorkPlace> {
     const seatGap = to.getDefenseDistance(this) - from.getOffenseDistance(this);
     return Math.max(this.onSeatDistance(from, to) + seatGap, 1);
   }
+
   public cardUseDistanceBetween(room: Room, cardId: CardId, from: Player, to: Player) {
     const card = Sanguosha.getCardById(cardId);
 

--- a/src/core/skills/characters/yijiang2013/qiuyuan.ts
+++ b/src/core/skills/characters/yijiang2013/qiuyuan.ts
@@ -1,0 +1,86 @@
+import { CardMatcher } from 'core/cards/libs/card_matcher';
+import { CardMoveReason, GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
+import { Sanguosha } from 'core/game/engine';
+import { AimStage, AllStage } from 'core/game/stage_processor';
+import { Player } from 'core/player/player';
+import { PlayerCardsArea, PlayerId } from 'core/player/player_props';
+import { Room } from 'core/room/room';
+import { TriggerSkill } from 'core/skills/skill';
+import { CommonSkill } from 'core/skills/skill_wrappers';
+import { TranslationPack } from 'core/translations/translation_json_tool';
+
+@CommonSkill({ name: 'qiuyuan', description: 'qiuyuan_description' })
+export class QiuYuan extends TriggerSkill {
+  public isTriggerable(_: ServerEventFinder<GameEventIdentifiers>, stage?: AllStage): boolean {
+    return stage === AimStage.OnAimmed;
+  }
+
+  public canUse(room: Room, owner: Player, event: ServerEventFinder<GameEventIdentifiers.AimEvent>): boolean {
+    if (!!event.byCardId && Sanguosha.getCardById(event.byCardId).GeneralName === 'slash' && event.toId === owner.Id) {
+      room.setFlag<PlayerId[]>(owner.Id, this.Name, [event.fromId, ...event.allTargets]);
+      return true;
+    }
+    return false;
+  }
+
+  public numberOfTargets(): number {
+    return 1;
+  }
+
+  public isAvailableTarget(owner: PlayerId, room: Room, target: PlayerId): boolean {
+    const invalidTargets = room.getPlayerById(owner).getFlag<PlayerId[]>(this.Name);
+    return !invalidTargets.includes(target);
+  }
+
+  public async onTrigger(): Promise<boolean> {
+    return true;
+  }
+
+  public async onEffect(
+    room: Room,
+    skillEffectEvent: ServerEventFinder<GameEventIdentifiers.SkillEffectEvent>,
+  ): Promise<boolean> {
+    const to = room.getPlayerById(skillEffectEvent.toIds![0]);
+
+    const askForCard: ServerEventFinder<GameEventIdentifiers.AskForCardEvent> = {
+      cardAmount: 1,
+      toId: to.Id,
+      fromArea: [PlayerCardsArea.HandArea],
+      cardMatcher: new CardMatcher({
+        name: ['jink'],
+      }).toSocketPassenger(),
+      conversation: TranslationPack.translationJsonPatcher(
+        '{0}: you need to give a jink to {1}',
+        this.Name,
+        TranslationPack.patchPlayerInTranslation(room.getPlayerById(skillEffectEvent.fromId)),
+      ).extract(),
+      reason: this.Name,
+    };
+
+    room.notify(GameEventIdentifiers.AskForCardEvent, askForCard, to.Id);
+
+    const { selectedCards } = await room.onReceivingAsyncResponseFrom(GameEventIdentifiers.AskForCardEvent, to.Id);
+
+    if (selectedCards) {
+      room.moveCards({
+        movingCards: [{ card: selectedCards[0], fromArea: PlayerCardsArea.HandArea }],
+        fromId: to.Id,
+        toId: skillEffectEvent.fromId,
+        toArea: PlayerCardsArea.HandArea,
+        moveReason: CardMoveReason.ActiveMove,
+        proposer: to.Id,
+        movedByReason: this.Name,
+        engagedPlayerIds: room.getAllPlayersFrom().map(player => player.Id),
+      });
+    } else {
+      if (room.canUseCardTo(new CardMatcher({ generalName: ['slash'] }), to.Id)) {
+        const aimEvent = skillEffectEvent.triggeredOnEvent as ServerEventFinder<GameEventIdentifiers.AimEvent>;
+        aimEvent.allTargets.push(to.Id);
+      }
+    }
+
+    room.removeFlag(skillEffectEvent.fromId, this.Name);
+
+    return true;
+  }
+}

--- a/src/core/skills/characters/yijiang2013/qiuyuan.ts
+++ b/src/core/skills/characters/yijiang2013/qiuyuan.ts
@@ -61,7 +61,7 @@ export class QiuYuan extends TriggerSkill {
 
     const { selectedCards } = await room.onReceivingAsyncResponseFrom(GameEventIdentifiers.AskForCardEvent, to.Id);
 
-    if (selectedCards) {
+    if (selectedCards.length) {
       room.moveCards({
         movingCards: [{ card: selectedCards[0], fromArea: PlayerCardsArea.HandArea }],
         fromId: to.Id,
@@ -73,7 +73,11 @@ export class QiuYuan extends TriggerSkill {
         engagedPlayerIds: room.getAllPlayersFrom().map(player => player.Id),
       });
     } else {
+      // tslint:disable-next-line: no-console
+      console.log('hit');
       if (room.canUseCardTo(new CardMatcher({ generalName: ['slash'] }), to.Id)) {
+        // tslint:disable-next-line: no-console
+        console.log('can hit');
         const aimEvent = skillEffectEvent.triggeredOnEvent as ServerEventFinder<GameEventIdentifiers.AimEvent>;
         aimEvent.allTargets.push(to.Id);
       }

--- a/src/core/skills/characters/yijiang2013/zhuikong.ts
+++ b/src/core/skills/characters/yijiang2013/zhuikong.ts
@@ -1,0 +1,79 @@
+import { CardMatcher } from 'core/cards/libs/card_matcher';
+import { CardId } from 'core/cards/libs/card_props';
+import { GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
+import { AllStage, PhaseStageChangeStage, PlayerPhase, PlayerPhaseStages } from 'core/game/stage_processor';
+import { Player } from 'core/player/player';
+import { Room } from 'core/room/room';
+import { GlobalFilterSkill, GlobalRulesBreakerSkill, OnDefineReleaseTiming, TriggerSkill } from 'core/skills/skill';
+import { CommonSkill, PersistentSkill } from 'core/skills/skill_wrappers';
+
+@CommonSkill({ name: 'zhuikong', description: 'zhuikong_description' })
+export class ZhuiKong extends TriggerSkill implements OnDefineReleaseTiming {
+  public static Filter: string = 'qiuyuan_filter';
+  public static DistanceBreak: string = 'distance_break';
+
+  public afterLosingSkill(room: Room): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.FinishStage;
+  }
+
+  public isRefreshAt(room: Room, owner: Player, phase: PlayerPhase): boolean {
+    return room.CurrentPhasePlayer === owner && phase === PlayerPhase.FinishStage;
+  }
+
+  public whenRefresh(room: Room, owner: Player): void {
+    for (const player of room.getOtherPlayers(owner.Id)) {
+      player.getFlag<boolean>(ZhuiKong.Filter) && room.removeFlag(player.Id, ZhuiKong.Filter);
+      player.getFlag<boolean>(ZhuiKong.DistanceBreak) && room.removeFlag(player.Id, ZhuiKong.DistanceBreak);
+    }
+  }
+
+  public isTriggerable(_: ServerEventFinder<GameEventIdentifiers>, stage?: AllStage): boolean {
+    return stage === PhaseStageChangeStage.StageChanged;
+  }
+
+  public canUse(_: Room, owner: Player, event: ServerEventFinder<GameEventIdentifiers.PhaseStageChangeEvent>): boolean {
+    return event.toStage === PlayerPhaseStages.PrepareStageStart && event.playerId !== owner.Id && owner.isInjured();
+  }
+
+  public async onTrigger(): Promise<boolean> {
+    return true;
+  }
+
+  public async onEffect(
+    room: Room,
+    skillEffectEvent: ServerEventFinder<GameEventIdentifiers.SkillEffectEvent>,
+  ): Promise<boolean> {
+    const { fromId, triggeredOnEvent } = skillEffectEvent;
+    const { playerId } = triggeredOnEvent as ServerEventFinder<GameEventIdentifiers.PhaseStageChangeEvent>;
+    const to = room.getPlayerById(playerId);
+
+    const pindianResult = await room.pindian(fromId, [playerId]);
+    if (!pindianResult) {
+      return false;
+    }
+
+    if (pindianResult.winners.includes(fromId)) {
+      room.setFlag<boolean>(to.Id, ZhuiKong.Filter, true);
+    } else {
+      room.setFlag<boolean>(to.Id, ZhuiKong.DistanceBreak, true);
+    }
+
+    return true;
+  }
+}
+
+@PersistentSkill
+@CommonSkill({ name: ZhuiKong.Name, description: ZhuiKong.Description })
+export class ZhuiKongFilter extends GlobalFilterSkill {
+  public canUseCardTo(_: CardId | CardMatcher, __: Room, ___: Player, from: Player, to: Player): boolean {
+    return !from.getFlag<boolean>(ZhuiKong.Filter) || to.Id === from.Id;
+  }
+}
+
+@PersistentSkill
+@CommonSkill({ name: ZhuiKongFilter.Name, description: ZhuiKongFilter.Description })
+export class ZhuiKongDistance extends GlobalRulesBreakerSkill {
+  public breakDistance(_: Room, owner: Player, from: Player, to: Player): number {
+    return from.getFlag<boolean>(ZhuiKong.DistanceBreak) && to.Id === owner.Id ? 1 : 0;
+  }
+}

--- a/src/core/skills/characters/yijiang2013/zhuikong.ts
+++ b/src/core/skills/characters/yijiang2013/zhuikong.ts
@@ -5,7 +5,7 @@ import { AllStage, PhaseStageChangeStage, PlayerPhase, PlayerPhaseStages } from 
 import { Player } from 'core/player/player';
 import { Room } from 'core/room/room';
 import { GlobalFilterSkill, GlobalRulesBreakerSkill, OnDefineReleaseTiming, TriggerSkill } from 'core/skills/skill';
-import { CommonSkill, PersistentSkill } from 'core/skills/skill_wrappers';
+import { CommonSkill, PersistentSkill, ShadowSkill } from 'core/skills/skill_wrappers';
 
 @CommonSkill({ name: 'zhuikong', description: 'zhuikong_description' })
 export class ZhuiKong extends TriggerSkill implements OnDefineReleaseTiming {
@@ -62,7 +62,8 @@ export class ZhuiKong extends TriggerSkill implements OnDefineReleaseTiming {
   }
 }
 
-@PersistentSkill
+@ShadowSkill
+@PersistentSkill()
 @CommonSkill({ name: ZhuiKong.Name, description: ZhuiKong.Description })
 export class ZhuiKongFilter extends GlobalFilterSkill {
   public canUseCardTo(_: CardId | CardMatcher, __: Room, ___: Player, from: Player, to: Player): boolean {
@@ -70,7 +71,8 @@ export class ZhuiKongFilter extends GlobalFilterSkill {
   }
 }
 
-@PersistentSkill
+@ShadowSkill
+@PersistentSkill()
 @CommonSkill({ name: ZhuiKongFilter.Name, description: ZhuiKongFilter.Description })
 export class ZhuiKongDistance extends GlobalRulesBreakerSkill {
   public breakDistance(_: Room, owner: Player, from: Player, to: Player): number {

--- a/src/core/skills/characters/yijiang2013/zhuikong.ts
+++ b/src/core/skills/characters/yijiang2013/zhuikong.ts
@@ -47,12 +47,12 @@ export class ZhuiKong extends TriggerSkill implements OnDefineReleaseTiming {
     const { playerId } = triggeredOnEvent as ServerEventFinder<GameEventIdentifiers.PhaseStageChangeEvent>;
     const to = room.getPlayerById(playerId);
 
-    const pindianResult = await room.pindian(fromId, [playerId]);
-    if (!pindianResult) {
+    const { pindianRecord } = await room.pindian(fromId, [playerId]);
+    if (!pindianRecord) {
       return false;
     }
 
-    if (pindianResult.winners.includes(fromId)) {
+    if (pindianRecord[0].winner === fromId) {
       room.setFlag<boolean>(to.Id, ZhuiKong.Filter, true);
     } else {
       room.setFlag<boolean>(to.Id, ZhuiKong.DistanceBreak, true);

--- a/src/core/skills/index.ts
+++ b/src/core/skills/index.ts
@@ -270,6 +270,8 @@ export { LongYin, LongYinClear } from './characters/yijiang2013/longyin';
 export { QiaoShuo, QiaoShuoLose, QiaoShuoWin } from './characters/yijiang2013/qiaoshuo';
 export { J3ZongShi } from './characters/yijiang2013/zongshi';
 export { DanShou, DanshouShadow } from './characters/yijiang2013/danshou';
+export { ZhuiKong, ZhuiKongFilter, ZhuiKongDistance } from './characters/yijiang2013/zhuikong';
+export { QiuYuan } from './characters/yijiang2013/qiuyuan';
 
 export { Cheat } from './system/cheat';
 export { BaHu, BaHuShadow } from './game_mode/1v2/bahu';

--- a/src/core/skills/skill.ts
+++ b/src/core/skills/skill.ts
@@ -506,6 +506,12 @@ export abstract class RulesBreakerSkill extends Skill {
   }
 }
 
+export abstract class GlobalRulesBreakerSkill extends RulesBreakerSkill {
+  public breakDistance(room: Room, owner: Player, from: Player, to: Player): number {
+    return 0;
+  }
+}
+
 export abstract class FilterSkill extends Skill {
   public canUse() {
     return true;

--- a/src/ui/platforms/desktop/src/languages/zh_CN/translations/standard.ts
+++ b/src/ui/platforms/desktop/src/languages/zh_CN/translations/standard.ts
@@ -67,6 +67,7 @@ export const characterDictionary: Word[] = [
   { source: 'jizhi', target: '集智' },
   { source: '#jizhi', target: '集智' },
   { source: 'qicai', target: '奇才' },
+  { source: '#qicai', target: '奇才' },
 
   { source: 'yiji_c', target: '伊籍' },
   { source: 'jijie', target: '机捷' },

--- a/src/ui/platforms/desktop/src/languages/zh_CN/translations/yijiang2013.ts
+++ b/src/ui/platforms/desktop/src/languages/zh_CN/translations/yijiang2013.ts
@@ -190,7 +190,6 @@ export const promptDescriptions: Word[] = [
     source: "{1} is appended to target list of {2} by {0}'s skill {3}",
     target: '{0}使用了技能{3}，将{1}添加至{2}的目标中',
   },
-
   {
     source: '{0}: do you want to drop {1} card(s) to deal 1 damage to {2} ?',
     target: '{0}：你可以弃置 {1} 张牌对 {2} 造成1点伤害',
@@ -198,5 +197,9 @@ export const promptDescriptions: Word[] = [
   {
     source: '{0}: do you want to deal 1 damage to {1} ?',
     target: '{0}：你可以对 {1} 造成1点伤害',
+  },
+  {
+    source: '{0}: you need to give a jink to {1}',
+    target: '{0}：请交给{1}一张【闪】，否则成为你将【杀】的目标之一',
   },
 ];


### PR DESCRIPTION
>【惴恐】其他角色的准备阶段开始时，若你已受伤，你可以与其拼点，若你：赢，其本回合内使用牌不能指定其他角色为目标；没赢，其至你的距离于本回合内视为1。
>【求援】当你成为【杀】的目标时，你可以选择不为使用者和此【杀】目标的一名其他角色，其选择一项：1.交给你一张【闪】；2.成为此【杀】的目标。
* 添加 GlobalRulesBreaker，支持对所有角色的规则控制
* 添加 @PersistentSkill，将该技能标识为持久技能，不能被无效化（继承自ShadowSkill）
* 修改了一下engagedPlayerIds的逻辑