### PR TITLE
Update skills

### DIFF
--- a/src/core/characters/wind/xiaoqiao.ts
+++ b/src/core/characters/wind/xiaoqiao.ts
@@ -9,6 +9,7 @@ export class XiaoQiao extends Character {
     super(id, 'xiaoqiao', CharacterGender.Female, CharacterNationality.Wu, 3, 3, GameCharacterExtensions.Wind, [
       ...skillLoaderInstance.getSkillsByName('hongyan'),
       skillLoaderInstance.getSkillByName('tianxiang'),
+      skillLoaderInstance.getSkillByName('piaoling'),
     ]);
   }
 }

--- a/src/core/characters/yijiang2011/lingtong.ts
+++ b/src/core/characters/yijiang2011/lingtong.ts
@@ -7,7 +7,8 @@ const skillLoaderInstance = SkillLoader.getInstance();
 export class LingTong extends Character {
   constructor(id: number) {
     super(id, 'lingtong', CharacterGender.Male, CharacterNationality.Wu, 4, 4, GameCharacterExtensions.YiJiang2011, [
-      ...skillLoaderInstance.getSkillsByName('xuanfeng'),
+      skillLoaderInstance.getSkillByName('xuanfeng'),
+      skillLoaderInstance.getSkillByName('yongjin'),
     ]);
   }
 }

--- a/src/core/game/version.ts
+++ b/src/core/game/version.ts
@@ -1,1 +1,1 @@
-export const coreVersion = '0.3.2.0';
+export const coreVersion = '0.3.2.1';

--- a/src/core/skills/characters/standard/tongji.ts
+++ b/src/core/skills/characters/standard/tongji.ts
@@ -1,32 +1,92 @@
-import { CardMatcher } from 'core/cards/libs/card_matcher';
-import { CardId } from 'core/cards/libs/card_props';
+import { CardMoveReason, GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
 import { Sanguosha } from 'core/game/engine';
+import { AimStage, AllStage } from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
 import { PlayerCardsArea } from 'core/player/player_props';
 import { Room } from 'core/room/room';
-import { GlobalFilterSkill } from 'core/skills/skill';
-import { CompulsorySkill } from 'core/skills/skill_wrappers';
+import { Precondition } from 'core/shares/libs/precondition/precondition';
+import { TriggerSkill } from 'core/skills/skill';
+import { CommonSkill } from 'core/skills/skill_wrappers';
+import { TranslationPack } from 'core/translations/translation_json_tool';
 
-@CompulsorySkill({ name: 'tongji', description: 'tongji_description' })
-export class TongJi extends GlobalFilterSkill {
-  canUseCardTo(cardId: CardId | CardMatcher, room: Room, owner: Player, attacker: Player, target: Player) {
-    if (cardId instanceof CardMatcher) {
-      if (!cardId.match(new CardMatcher({ generalName: ['slash'] }))) {
-        return true;
-      }
-    } else {
-      if (Sanguosha.getCardById(cardId).GeneralName !== 'slash') {
-        return true;
-      }
-    }
+@CommonSkill({ name: 'tongji', description: 'tongji_description' })
+export class TongJi extends TriggerSkill {
+  public isAutoTrigger(): boolean {
+    return true;
+  }
 
-    if (attacker === owner || owner.getCardIds(PlayerCardsArea.HandArea).length <= owner.Hp) {
+  public isTriggerable(event: ServerEventFinder<GameEventIdentifiers.AimEvent>, stage?: AllStage): boolean {
+    return (
+      stage === AimStage.OnAimmed &&
+      event.byCardId !== undefined &&
+      Sanguosha.getCardById(event.byCardId).GeneralName === 'slash'
+    );
+  }
+
+  public canUse(room: Room, owner: Player, event: ServerEventFinder<GameEventIdentifiers.AimEvent>): boolean {
+    const to = room.getPlayerById(event.toId);
+
+    return (
+      event.toId !== owner.Id &&
+      event.fromId !== owner.Id &&
+      to.getAttackDistance(room) >= room.distanceBetween(to, owner) &&
+      !event.allTargets.includes(owner.Id)
+    );
+  }
+
+  public async beforeUse(room: Room, event: ServerEventFinder<GameEventIdentifiers.SkillUseEvent>): Promise<boolean> {
+    const { fromId, triggeredOnEvent } = event;
+    const aimEvent = triggeredOnEvent as ServerEventFinder<GameEventIdentifiers.AimEvent>;
+
+    const response = await room.askForCardDrop(
+      aimEvent.toId,
+      1,
+      [PlayerCardsArea.HandArea, PlayerCardsArea.EquipArea],
+      false,
+      undefined,
+      this.Name,
+      TranslationPack.translationJsonPatcher(
+        '{0}: do you want to discard 1 card to transfer the target of {1} to {2}',
+        this.Name,
+        TranslationPack.patchCardInTranslation(aimEvent.byCardId!),
+        TranslationPack.patchPlayerInTranslation(room.getPlayerById(fromId)),
+      ).extract(),
+    );
+
+    if (response.droppedCards.length > 0) {
+      event.cardIds = response.droppedCards;
       return true;
     }
+    
+    return false;
+  }
 
-    if (attacker.getAttackDistance(room) >= room.distanceBetween(attacker, owner)) {
-      return target === owner;
-    }
+  public async onTrigger(room: Room, event: ServerEventFinder<GameEventIdentifiers.SkillEffectEvent>): Promise<boolean> {
+    const { fromId, triggeredOnEvent } = event;
+    const aimEvent = triggeredOnEvent as ServerEventFinder<GameEventIdentifiers.AimEvent>;
+
+    event.translationsMessage = TranslationPack.translationJsonPatcher(
+      '{0} used skill {1}, transfer the target of {1} to {2}',
+      this.Name,
+      TranslationPack.patchCardInTranslation(aimEvent.byCardId!),
+      TranslationPack.patchPlayerInTranslation(room.getPlayerById(fromId)),
+    ).extract();
+
+    return true;
+  }
+
+  public async onEffect(room: Room, event: ServerEventFinder<GameEventIdentifiers.SkillEffectEvent>): Promise<boolean> {
+    const { triggeredOnEvent, cardIds, fromId } = event;
+    const aimEvent = triggeredOnEvent as ServerEventFinder<GameEventIdentifiers.AimEvent>;
+
+    await room.dropCards(CardMoveReason.SelfDrop, cardIds!, aimEvent.toId, aimEvent.toId, this.Name);
+
+    const index = aimEvent.allTargets.findIndex(toId => toId === aimEvent.toId);
+    Precondition.assert(index >= 0, `Unable to find source player of ${this.Name}`);
+    aimEvent.allTargets.splice(index, 1);
+    aimEvent.allTargets.push(fromId);
+    room.sortPlayersByPosition(aimEvent.allTargets);
+    aimEvent.toId = fromId;
 
     return true;
   }

--- a/src/core/skills/characters/wind/piaoling.ts
+++ b/src/core/skills/characters/wind/piaoling.ts
@@ -1,0 +1,112 @@
+import { Card, VirtualCard } from 'core/cards/card';
+import { CardId, CardSuit } from 'core/cards/libs/card_props';
+import { CardMoveArea, CardMoveReason, EventPacker, GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
+import { Sanguosha } from 'core/game/engine';
+import { AllStage, PhaseStageChangeStage, PlayerPhaseStages } from 'core/game/stage_processor';
+import { Player } from 'core/player/player';
+import { PlayerCardsArea } from 'core/player/player_props';
+import { Room } from 'core/room/room';
+import { CommonSkill, TriggerSkill } from 'core/skills/skill';
+
+@CommonSkill({ name: 'piaoling', description: 'piaoling_description' })
+export class PiaoLing extends TriggerSkill {
+  isTriggerable(event: ServerEventFinder<GameEventIdentifiers.PhaseStageChangeEvent>, stage?: AllStage) {
+    return stage === PhaseStageChangeStage.StageChanged;
+  }
+
+  canUse(room: Room, owner: Player) {
+    return room.CurrentPlayerStage === PlayerPhaseStages.PhaseFinishStart && room.CurrentPlayer.Id === owner.Id;
+  }
+
+  async onTrigger(room: Room, skillUseEvent: ServerEventFinder<GameEventIdentifiers.SkillUseEvent>) {
+    return true;
+  }
+
+  async onEffect(room: Room, skillUseEvent: ServerEventFinder<GameEventIdentifiers.SkillEffectEvent>) {
+    const { fromId } = skillUseEvent;
+    const judgeResult = await room.judge(fromId, undefined, this.Name);
+    const card = Sanguosha.getCardById(judgeResult.judgeCardId);
+    if (card.Suit !== CardSuit.Heart) {
+      return false;
+    }
+
+    const askForOptions: ServerEventFinder<GameEventIdentifiers.AskForChoosingOptionsEvent> = {
+      toId: fromId,
+      options: ['option-one', 'option-two'],
+      conversation: '#piaoling-select',
+    };
+
+    room.notify(
+      GameEventIdentifiers.AskForChoosingOptionsEvent,
+      EventPacker.createUncancellableEvent<GameEventIdentifiers.AskForChoosingOptionsEvent>(askForOptions),
+      fromId,
+    );
+    const { selectedOption } = await room.onReceivingAsyncResponseFrom(
+      GameEventIdentifiers.AskForChoosingOptionsEvent,
+      fromId,
+    );
+
+    const cards: CardId[] = [];
+    if (Card.isVirtualCardId(judgeResult.judgeCardId)) {
+      cards.push(...(card as VirtualCard).ActualCardIds);
+    } else {
+      cards.push(card.Id);
+    }
+
+    if (selectedOption === askForOptions.options[0]) {
+      await room.moveCards({
+        movingCards: cards.map(card => ({ card, fromArea: CardMoveArea.DropStack })),
+        moveReason: CardMoveReason.ActiveMove,
+        toArea: CardMoveArea.DrawStack,
+        movedByReason: this.Name,
+      });
+    } else {
+      const askForPlayer: ServerEventFinder<GameEventIdentifiers.AskForChoosingPlayerEvent> = {
+        toId: fromId,
+        players: room.AlivePlayers.map(p => p.Id),
+        conversation: 'piaoling: select a player to obtain the judge card',
+        requiredAmount: 1,
+      };
+
+      room.notify(
+        GameEventIdentifiers.AskForChoosingPlayerEvent,
+        EventPacker.createUncancellableEvent<GameEventIdentifiers.AskForChoosingPlayerEvent>(askForPlayer),
+        fromId,
+      );
+      const { selectedPlayers } = await room.onReceivingAsyncResponseFrom(
+        GameEventIdentifiers.AskForChoosingPlayerEvent,
+        fromId,
+      );
+
+      await room.moveCards({
+        movingCards: cards.map(card => ({ card, fromArea: CardMoveArea.DropStack })),
+        moveReason: CardMoveReason.ActiveMove,
+        toArea: CardMoveArea.HandArea,
+        toId: selectedPlayers![0],
+        movedByReason: this.Name,
+      });
+
+      if (fromId === selectedPlayers![0]) {
+        const askForDropCard: ServerEventFinder<GameEventIdentifiers.AskForCardDropEvent> = {
+          toId: fromId,
+          fromArea: [PlayerCardsArea.HandArea, PlayerCardsArea.EquipArea],
+          cardAmount: 1,
+          triggeredBySkills: [this.Name],
+        };
+
+        room.notify(
+          GameEventIdentifiers.AskForCardDropEvent,
+          EventPacker.createUncancellableEvent<GameEventIdentifiers.AskForCardDropEvent>(askForDropCard),
+          fromId,
+        );
+        const { droppedCards } = await room.onReceivingAsyncResponseFrom(
+          GameEventIdentifiers.AskForCardDropEvent,
+          fromId,
+        );
+
+        await room.dropCards(CardMoveReason.SelfDrop, droppedCards, fromId, fromId, this.Name);
+      }
+    }
+    return true;
+  }
+}

--- a/src/core/skills/characters/wind/tianxiang.ts
+++ b/src/core/skills/characters/wind/tianxiang.ts
@@ -32,7 +32,7 @@ export class TianXiang extends TriggerSkill {
   }
 
   public availableCardAreas() {
-    return [PlayerCardsArea.HandArea];
+    return [PlayerCardsArea.HandArea, PlayerCardsArea.EquipArea];
   }
 
   cardFilter(room: Room, owner: Player, cards: CardId[]): boolean {

--- a/src/core/skills/characters/yijiang2011/sanyao.ts
+++ b/src/core/skills/characters/yijiang2011/sanyao.ts
@@ -1,27 +1,35 @@
 import { CardId } from 'core/cards/libs/card_props';
-import { CardMoveReason, GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
+import { CardMoveReason, EventPacker, GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
 import { DamageType } from 'core/game/game_props';
+import { PlayerPhase } from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
-import { PlayerId } from 'core/player/player_props';
+import { PlayerCardsArea, PlayerId } from 'core/player/player_props';
 import { Room } from 'core/room/room';
 import { ActiveSkill, CommonSkill } from 'core/skills/skill';
 
 @CommonSkill({ name: 'sanyao', description: 'sanyao_description' })
 export class SanYao extends ActiveSkill {
+  public static readonly MostHp = 'SanYao_MostHp';
+  public static readonly MostHandNum = 'SanYao_MostHandNum';
+
+  public isRefreshAt(room: Room, owner: Player, phase: PlayerPhase): boolean {
+    return phase === PlayerPhase.PlayCardStage;
+  }
+
+  public async whenRefresh(room: Room, owner: Player) {
+    room.removeFlag(owner.Id, SanYao.MostHp);
+    room.removeFlag(owner.Id, SanYao.MostHandNum);
+  }
+
   public canUse(room: Room, owner: Player): boolean {
-    return !owner.hasUsedSkill(this.Name) && owner.getPlayerCards().length > 0;
+    return owner.hasUsedSkillTimes(this.Name) < 2 && owner.getPlayerCards().length > 0;
   }
 
   public numberOfTargets(): number[] {
     return [];
   }
 
-  public targetFilter(
-    room: Room,
-    owner: Player,
-    targets: PlayerId[],
-    selectedCards: CardId[],
-  ): boolean {
+  public targetFilter(room: Room, owner: Player, targets: PlayerId[], selectedCards: CardId[]): boolean {
     return targets.length === selectedCards.length;
   }
 
@@ -30,9 +38,19 @@ export class SanYao extends ActiveSkill {
   }
 
   public isAvailableTarget(owner: PlayerId, room: Room, target: PlayerId): boolean {
+    const ownerPlayer = room.getPlayerById(owner);
+    const targetPlayer = room.getPlayerById(target);
+
     return (
-      owner !== target &&
-      room.getOtherPlayers(owner).find(player => player.Hp > room.getPlayerById(target).Hp) === undefined
+      (ownerPlayer.getFlag<boolean>(SanYao.MostHp) !== true &&
+        room.getAlivePlayersFrom().find(player => player.Hp > targetPlayer.Hp) === undefined) ||
+      (ownerPlayer.getFlag<boolean>(SanYao.MostHandNum) !== true &&
+        room.getAlivePlayersFrom().find(player => {
+          return (
+            player.getCardIds(PlayerCardsArea.HandArea).length >
+            targetPlayer.getCardIds(PlayerCardsArea.HandArea).length
+          );
+        }) === undefined)
     );
   }
 
@@ -44,26 +62,59 @@ export class SanYao extends ActiveSkill {
     return true;
   }
 
-  public async onEffect(
-    room: Room,
-    skillUseEvent: ServerEventFinder<GameEventIdentifiers.SkillEffectEvent>,
-  ): Promise<boolean> {
-    await room.dropCards(
-      CardMoveReason.SelfDrop,
-      skillUseEvent.cardIds!,
-      skillUseEvent.fromId,
-      skillUseEvent.fromId,
-      this.Name,
-    );
+  public async onEffect(room: Room, event: ServerEventFinder<GameEventIdentifiers.SkillEffectEvent>): Promise<boolean> {
+    const { fromId, toIds, cardIds } = event;
+    const target = room.getPlayerById(toIds![0]);
+    const from = room.getPlayerById(fromId);
 
-    for (const toId of skillUseEvent.toIds!) {
+    const hasMostHp = room.getOtherPlayers(toIds![0]).find(player => player.Hp > target.Hp) === undefined;
+    const hasMostHandNum =
+      room.getOtherPlayers(toIds![0]).find(player => {
+        return player.getCardIds(PlayerCardsArea.HandArea).length > target.getCardIds(PlayerCardsArea.HandArea).length;
+      }) === undefined;
+
+    if (
+      hasMostHp &&
+      hasMostHandNum &&
+      from.getFlag<boolean>(SanYao.MostHp) !== true &&
+      from.getFlag<boolean>(SanYao.MostHandNum) !== true
+    ) {
+      const askForChooseEvent = EventPacker.createUncancellableEvent<GameEventIdentifiers.AskForChoosingOptionsEvent>({
+        options: ['sanyao:hp', 'sanyao:handNum'],
+        conversation: 'please choose sanyao options',
+        toId: fromId,
+      });
+
+      room.notify(
+        GameEventIdentifiers.AskForChoosingOptionsEvent,
+        EventPacker.createUncancellableEvent<GameEventIdentifiers.AskForChoosingOptionsEvent>(askForChooseEvent),
+        fromId,
+      );
+
+      const response = await room.onReceivingAsyncResponseFrom(GameEventIdentifiers.AskForChoosingOptionsEvent, fromId);
+      response.selectedOption = response.selectedOption || 'sanyao:hp';
+
+      if (response.selectedOption === 'sanyap:handNum') {
+        room.setFlag<boolean>(fromId, SanYao.MostHandNum, true);
+      } else {
+        room.setFlag<boolean>(fromId, SanYao.MostHp, true);
+      }
+    } else if (hasMostHp) {
+      room.setFlag<boolean>(fromId, SanYao.MostHp, true);
+    } else if (hasMostHandNum) {
+      room.setFlag<boolean>(fromId, SanYao.MostHandNum, true);
+    }
+
+    await room.dropCards(CardMoveReason.SelfDrop, cardIds!, fromId, fromId, this.Name);
+
+    for (const toId of toIds!) {
       const to = room.getPlayerById(toId);
       if (to.Dead) {
         continue;
       }
 
       await room.damage({
-        fromId: skillUseEvent.fromId,
+        fromId,
         toId,
         damage: 1,
         damageType: DamageType.Normal,

--- a/src/core/skills/characters/yijiang2011/sanyao.ts
+++ b/src/core/skills/characters/yijiang2011/sanyao.ts
@@ -92,16 +92,16 @@ export class SanYao extends ActiveSkill {
       );
 
       const response = await room.onReceivingAsyncResponseFrom(GameEventIdentifiers.AskForChoosingOptionsEvent, fromId);
-      response.selectedOption = response.selectedOption || 'sanyao:hp';
+      response.selectedOption = response.selectedOption || askForChooseEvent.options[0];
 
-      if (response.selectedOption === 'sanyap:handNum') {
+      if (response.selectedOption === askForChooseEvent.options[1]) {
         room.setFlag<boolean>(fromId, SanYao.MostHandNum, true);
       } else {
         room.setFlag<boolean>(fromId, SanYao.MostHp, true);
       }
     } else if (hasMostHp) {
       room.setFlag<boolean>(fromId, SanYao.MostHp, true);
-    } else if (hasMostHandNum) {
+    } else {
       room.setFlag<boolean>(fromId, SanYao.MostHandNum, true);
     }
 

--- a/src/core/skills/characters/yijiang2011/sanyao.ts
+++ b/src/core/skills/characters/yijiang2011/sanyao.ts
@@ -16,6 +16,7 @@ export class SanYao extends ActiveSkill {
     return phase === PlayerPhase.PlayCardStage;
   }
 
+  //TODO: use a shadow skill to remove flags
   public async whenRefresh(room: Room, owner: Player) {
     room.removeFlag(owner.Id, SanYao.MostHp);
     room.removeFlag(owner.Id, SanYao.MostHandNum);

--- a/src/core/skills/characters/yijiang2011/xuanfeng.ts
+++ b/src/core/skills/characters/yijiang2011/xuanfeng.ts
@@ -1,11 +1,6 @@
-import { CardChoosingOptions, CardId } from 'core/cards/libs/card_props';
-import {
-  CardMoveArea,
-  CardMoveReason,
-  EventPacker,
-  GameEventIdentifiers,
-  ServerEventFinder,
-} from 'core/event/event';
+import { CardChoosingOptions } from 'core/cards/libs/card_props';
+import { CardMoveArea, CardMoveReason, EventPacker, GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
+import { DamageType } from 'core/game/game_props';
 import {
   AllStage,
   CardMoveStage,
@@ -16,17 +11,12 @@ import {
 import { Player } from 'core/player/player';
 import { PlayerCardsArea, PlayerId } from 'core/player/player_props';
 import { Room } from 'core/room/room';
-import { CommonSkill, ShadowSkill, TriggerSkill } from 'core/skills/skill';
-import { TranslationPack } from 'core/translations/translation_json_tool';
+import { Precondition } from 'core/shares/libs/precondition/precondition';
+import { CommonSkill, TriggerSkill } from 'core/skills/skill';
+import { PatchedTranslationObject, TranslationPack } from 'core/translations/translation_json_tool';
 
 @CommonSkill({ name: 'xuanfeng', description: 'xuanfeng_description' })
 export class XuanFeng extends TriggerSkill {
-  private readonly xuanFengTargets = 'xuanfeng_targets';
-
-  public isAutoTrigger(): boolean {
-    return true;
-  }
-
   public isTriggerable(
     event: ServerEventFinder<GameEventIdentifiers.PhaseStageChangeEvent | GameEventIdentifiers.MoveCardEvent>,
     stage?: AllStage,
@@ -43,10 +33,9 @@ export class XuanFeng extends TriggerSkill {
 
     if (unknownEvent === GameEventIdentifiers.PhaseStageChangeEvent) {
       const phaseStageChangeEvent = content as ServerEventFinder<GameEventIdentifiers.PhaseStageChangeEvent>;
-      let isUseable = (
+      let isUseable =
         owner.Id === phaseStageChangeEvent.playerId &&
-        phaseStageChangeEvent.toStage === PlayerPhaseStages.DropCardStageEnd
-      );
+        phaseStageChangeEvent.toStage === PlayerPhaseStages.DropCardStageEnd;
       if (isUseable) {
         let droppedCardNum = 0;
         const moveEvents = room.Analytics.getRecordEvents<GameEventIdentifiers.MoveCardEvent>(
@@ -62,7 +51,7 @@ export class XuanFeng extends TriggerSkill {
         for (const moveEvent of moveEvents) {
           droppedCardNum += moveEvent.movingCards.filter(card => card.fromArea === CardMoveArea.HandArea).length;
         }
-  
+
         isUseable = droppedCardNum >= 2;
       }
       return isUseable;
@@ -71,97 +60,26 @@ export class XuanFeng extends TriggerSkill {
       const equipCards = moveCardEvent.movingCards.filter(card => card.fromArea === CardMoveArea.EquipArea);
       return owner.Id === moveCardEvent.fromId && equipCards.length > 0;
     }
-    
-    return false;
-  }
-
-  public async beforeUse(
-    room: Room,
-    event: ServerEventFinder<GameEventIdentifiers.SkillUseEvent>,
-  ): Promise<boolean> {
-    const { fromId } = event;
-    let targets: string[] | undefined;
-
-    while (!targets) {
-      const askForChoosingOptionsEvent: ServerEventFinder<GameEventIdentifiers.AskForChoosingOptionsEvent> = {
-        options: ['xuanfeng:move', 'xuanfeng:drop', 'cancel'],
-        toId: fromId,
-        conversation: TranslationPack.translationJsonPatcher(
-          '{0}: please choose',
-          this.Name,
-        ).extract(),
-        ignoreNotifiedStatus: true,
-      };
-  
-      room.notify(
-        GameEventIdentifiers.AskForChoosingOptionsEvent,
-        EventPacker.createUncancellableEvent<GameEventIdentifiers.AskForChoosingOptionsEvent>(askForChoosingOptionsEvent),
-        fromId,
-      );
-  
-      const response = await room.onReceivingAsyncResponseFrom(GameEventIdentifiers.AskForChoosingOptionsEvent, fromId);
-      response.selectedOption = response.selectedOption || 'cancel';
-
-      if (response.selectedOption === 'cancel') {
-        break;
-      }
-
-      const skillUseEvent = {
-        invokeSkillNames: response.selectedOption === 'xuanfeng:move' ? [XuanFengMove.Name] : [XuanFengDrop.Name],
-        toId: fromId,
-        conversation: response.selectedOption === 'xuanfeng:move'
-        ? TranslationPack.translationJsonPatcher(
-          '{0}: please choose two target to move their equipment',
-          this.Name,
-        ).extract()
-        : TranslationPack.translationJsonPatcher(
-          '{0}: please choose a target to drop card',
-          this.Name,
-        ).extract(),
-        ignoreNotifiedStatus: true,
-      }
-      
-      room.notify(
-        GameEventIdentifiers.AskForSkillUseEvent,
-        skillUseEvent,
-        fromId,
-      );
-  
-      const { toIds } = await room.onReceivingAsyncResponseFrom(
-        GameEventIdentifiers.AskForSkillUseEvent,
-        fromId,
-      );
-      targets = toIds;
-    }
-
-    if (targets && targets.length > 0) {
-      EventPacker.addMiddleware({ tag: this.xuanFengTargets, data: targets }, event);
-      return true;
-    }
 
     return false;
   }
 
-  public getAnimationSteps(event: ServerEventFinder<GameEventIdentifiers.SkillUseEvent>) {
-    const { fromId } = event;
-    const toIds = EventPacker.getMiddleware<PlayerId[]>(this.xuanFengTargets, event);
-
-    if (toIds!.length === 2) {
-      return [
-        { from: fromId, tos: [toIds![0]] },
-        { from: toIds![0], tos: [toIds![1]] },
-      ];
-    }
-    
-    return toIds ? [{ from: fromId, tos: toIds }] : [];
+  public numberOfTargets(): number {
+    return 1;
   }
 
-  public async onTrigger(
-    room: Room,
-    event: ServerEventFinder<GameEventIdentifiers.SkillUseEvent>,
-  ): Promise<boolean> {
-    event.animation = this.getAnimationSteps(event);
+  public isAvailableTarget(owner: PlayerId, room: Room, target: PlayerId): boolean {
+    return owner !== target && room.getPlayerById(target).getPlayerCards().length > 0;
+  }
 
+  public getSkillLog(): PatchedTranslationObject {
+    return TranslationPack.translationJsonPatcher(
+      '{0}: do you want to choose a target to drop a card?',
+      this.Name,
+    ).extract();
+  }
+
+  public async onTrigger(): Promise<boolean> {
     return true;
   }
 
@@ -198,177 +116,76 @@ export class XuanFeng extends TriggerSkill {
       response.selectedCard = cardIds[Math.floor(Math.random() * cardIds.length)];
     }
 
-    await room.dropCards(
-      CardMoveReason.PassiveDrop,
-      [response.selectedCard],
-      chooseCardEvent.toId,
-      fromId,
-      this.Name,
-    );
+    await room.dropCards(CardMoveReason.PassiveDrop, [response.selectedCard], chooseCardEvent.toId, fromId, this.Name);
   }
 
-  public async onEffect(
-    room: Room,
-    event: ServerEventFinder<GameEventIdentifiers.SkillEffectEvent>,
-  ): Promise<boolean> {
+  public async onEffect(room: Room, event: ServerEventFinder<GameEventIdentifiers.SkillEffectEvent>): Promise<boolean> {
     const { fromId } = event;
-    const toIds = EventPacker.getMiddleware<PlayerId[]>(this.xuanFengTargets, event);
+    const targetIds = Precondition.exists(event.toIds, 'Unable to get xuanfeng targets');
+    const xuanfengTargets: PlayerId[] = [];
 
-    if (toIds!.length === 1) {
-      await this.xuanFengDropCard(room, fromId, toIds![0]);
+    await this.xuanFengDropCard(room, fromId, targetIds[0]);
+    xuanfengTargets.push(targetIds[0]);
 
-      const targets = room.getOtherPlayers(fromId)
-        .filter(player => player.getPlayerCards().length > 0)
-        .map(player => player.Id);
-  
-      if (targets.length > 0) {
-        const choosePlayerEvent: ServerEventFinder<GameEventIdentifiers.AskForChoosingPlayerEvent> = {
-          players: targets,
-          toId: fromId,
-          requiredAmount: 1,
-          conversation: TranslationPack.translationJsonPatcher(
-            '{0}: please choose a target to drop card',
-            this.Name,
-          ).extract(),
-        };
-  
-        room.notify(GameEventIdentifiers.AskForChoosingPlayerEvent, choosePlayerEvent, fromId);
-  
-        const choosePlayerResponse = await room.onReceivingAsyncResponseFrom(
-          GameEventIdentifiers.AskForChoosingPlayerEvent,
-          fromId,
-        );
-        
-        const chosenOne = choosePlayerResponse.selectedPlayers
-        if (chosenOne && chosenOne.length === 1) {
-          await this.xuanFengDropCard(room, fromId, chosenOne[0]);
-        }
-      }
-    } else if (toIds!.length === 2) {
-      const moveFrom = room.getPlayerById(toIds![0]);
-      const moveTo = room.getPlayerById(toIds![1]);
-      const canMovedEquipCardIds: CardId[] = [];
+    const targets = room
+      .getOtherPlayers(fromId)
+      .filter(player => player.getPlayerCards().length > 0)
+      .map(player => player.Id);
 
-      const fromEquipArea = moveFrom.getCardIds(PlayerCardsArea.EquipArea);
-      canMovedEquipCardIds.push(...fromEquipArea.filter(id => room.canPlaceCardTo(id, moveTo.Id)));
-
-      const options: CardChoosingOptions = {
-        [PlayerCardsArea.EquipArea]: canMovedEquipCardIds,
-      };
-
-      const chooseCardEvent = {
-        fromId,
+    if (targets.length > 0) {
+      const choosePlayerEvent: ServerEventFinder<GameEventIdentifiers.AskForChoosingPlayerEvent> = {
+        players: targets,
         toId: fromId,
-        options,
+        requiredAmount: 1,
+        conversation: TranslationPack.translationJsonPatcher(
+          '{0}: do you want to choose a target to drop a card?',
+          this.Name,
+        ).extract(),
       };
 
-      room.notify(
-        GameEventIdentifiers.AskForChoosingCardFromPlayerEvent,
-        EventPacker.createUncancellableEvent<GameEventIdentifiers.AskForChoosingCardFromPlayerEvent>(chooseCardEvent),
+      room.notify(GameEventIdentifiers.AskForChoosingPlayerEvent, choosePlayerEvent, fromId);
+
+      const choosePlayerResponse = await room.onReceivingAsyncResponseFrom(
+        GameEventIdentifiers.AskForChoosingPlayerEvent,
         fromId,
       );
 
-      const response = await room.onReceivingAsyncResponseFrom(
-        GameEventIdentifiers.AskForChoosingCardFromPlayerEvent,
+      const chosenOne = choosePlayerResponse.selectedPlayers;
+      if (chosenOne) {
+        await this.xuanFengDropCard(room, fromId, chosenOne[0]);
+        xuanfengTargets.push(chosenOne[0]);
+      }
+    }
+
+    if (room.CurrentPlayer === room.getPlayerById(fromId) && xuanfengTargets.length > 0) {
+      const askForPlayerChoose: ServerEventFinder<GameEventIdentifiers.AskForChoosingPlayerEvent> = {
+        toId: fromId,
+        players: xuanfengTargets,
+        requiredAmount: 1,
+        conversation: TranslationPack.translationJsonPatcher(
+          '{0}: do you want to choose a XuanFeng target to deal 1 damage?',
+          this.Name,
+        ).extract(),
+        triggeredBySkills: [this.Name],
+      };
+
+      room.notify(GameEventIdentifiers.AskForChoosingPlayerEvent, askForPlayerChoose, fromId);
+
+      const { selectedPlayers } = await room.onReceivingAsyncResponseFrom(
+        GameEventIdentifiers.AskForChoosingPlayerEvent,
         fromId,
       );
-
-      await room.moveCards({
-        movingCards: [{ card: response.selectedCard!, fromArea: response.fromArea }],
-        moveReason: CardMoveReason.PassiveMove,
-        toId: moveTo.Id,
-        fromId: moveFrom.Id,
-        toArea: response.fromArea!,
-        proposer: chooseCardEvent.fromId,
-        movedByReason: this.Name,
-      });
+      if (selectedPlayers) {
+        await room.damage({
+          fromId,
+          toId: selectedPlayers[0],
+          damage: 1,
+          damageType: DamageType.Normal,
+          triggeredBySkills: [this.Name],
+        });
+      }
     }
 
-    return true;
-  }
-}
-
-@ShadowSkill
-@CommonSkill({ name: XuanFeng.Name, description: XuanFeng.Description })
-export class XuanFengMove extends TriggerSkill {
-  public isTriggerable(): boolean {
-    return false;
-  }
-
-  public canUse(): boolean {
-    return false;
-  }
-
-  public numberOfTargets(): number {
-    return 2;
-  }
-
-  public isAvailableTarget(
-    owner: PlayerId,
-    room: Room,
-    target: PlayerId,
-    selectedCards: CardId[],
-    selectedTargets: PlayerId[],
-  ): boolean {
-    const to = room.getPlayerById(target);
-    const equiprCardIds = to.getCardIds(PlayerCardsArea.EquipArea);
-
-    if (target === owner) {
-      return false;
-    }
-
-    if (selectedTargets.length === 0) {
-      return equiprCardIds.length > 0;
-    } else if (selectedTargets.length === 1) {
-      let canBeTarget: boolean = false;
-      const from = room.getPlayerById(selectedTargets[0]);
-
-      const fromEquipArea = from.getCardIds(PlayerCardsArea.EquipArea);
-      canBeTarget = canBeTarget || fromEquipArea.find(id => room.canPlaceCardTo(id, target)) !== undefined;
-
-      return canBeTarget;
-    }
-
-    return false;
-  }
-
-  public nominateForwardTarget(targets: PlayerId[]) {
-    return [targets[0]];
-  }
-
-  public async onTrigger(): Promise<boolean> {
-    return true;
-  }
-
-  public async onEffect(): Promise<boolean> {
-    return true;
-  }
-}
-
-@ShadowSkill
-@CommonSkill({ name: XuanFengMove.Name, description: XuanFengMove.Description })
-export class XuanFengDrop extends TriggerSkill {
-  public isTriggerable(): boolean {
-    return false;
-  }
-
-  public canUse(): boolean {
-    return false;
-  }
-
-  public numberOfTargets(): number {
-    return 1;
-  }
-
-  public isAvailableTarget(owner: PlayerId, room: Room, target: PlayerId): boolean {
-    return target !== owner && room.getPlayerById(target).getPlayerCards().length > 0;
-  }
-
-  public async onTrigger(): Promise<boolean> {
-    return true;
-  }
-
-  public async onEffect(): Promise<boolean> {
     return true;
   }
 }

--- a/src/core/skills/characters/yijiang2011/yongjin.ts
+++ b/src/core/skills/characters/yijiang2011/yongjin.ts
@@ -1,0 +1,219 @@
+import { CardChoosingOptions, CardId } from 'core/cards/libs/card_props';
+import {
+  CardMoveReason,
+  ClientEventFinder,
+  EventPacker,
+  GameEventIdentifiers,
+  ServerEventFinder,
+} from 'core/event/event';
+import { Player } from 'core/player/player';
+import { PlayerCardsArea, PlayerId } from 'core/player/player_props';
+import { Room } from 'core/room/room';
+import { Precondition } from 'core/shares/libs/precondition/precondition';
+import { ActiveSkill, CommonSkill, LimitSkill, ShadowSkill, TriggerSkill } from 'core/skills/skill';
+import { TranslationPack } from 'core/translations/translation_json_tool';
+
+@LimitSkill({ name: 'yongjin', description: 'yongjin_description' })
+export class YongJin extends ActiveSkill {
+  public canUse(room: Room, owner: Player): boolean {
+    return true;
+  }
+
+  public cardFilter(room: Room, owner: Player, cards: CardId[]): boolean {
+    return cards.length === 0;
+  }
+
+  public numberOfTargets(): number {
+    return 2;
+  }
+
+  public isAvailableCard(): boolean {
+    return false;
+  }
+
+  public isAvailableTarget(
+    owner: PlayerId,
+    room: Room,
+    target: PlayerId,
+    selectedCards: CardId[],
+    selectedTargets: PlayerId[],
+  ): boolean {
+    const to = room.getPlayerById(target);
+    const equiprCardIds = to.getCardIds(PlayerCardsArea.EquipArea);
+
+    if (selectedTargets.length === 0) {
+      return equiprCardIds.length > 0;
+    } else if (selectedTargets.length === 1) {
+      let canBeTarget: boolean = false;
+      const from = room.getPlayerById(selectedTargets[0]);
+
+      const fromEquipArea = from.getCardIds(PlayerCardsArea.EquipArea);
+      canBeTarget = canBeTarget || fromEquipArea.find(id => room.canPlaceCardTo(id, target)) !== undefined;
+
+      return canBeTarget;
+    }
+
+    return false;
+  }
+
+  public nominateForwardTarget(targets?: PlayerId[]) {
+    return [targets![0]];
+  }
+
+  public getAnimationSteps(event: ServerEventFinder<GameEventIdentifiers.SkillUseEvent>) {
+    const { fromId, toIds } = event;
+
+    return [
+      { from: fromId, tos: [toIds![0]] },
+      { from: toIds![0], tos: [toIds![1]] },
+    ];
+  }
+
+  public async onUse(room: Room, event: ClientEventFinder<GameEventIdentifiers.SkillUseEvent>): Promise<boolean> {
+    event.animation = this.getAnimationSteps(event);
+
+    return true;
+  }
+
+  private async yongJinMove(room: Room, user: PlayerId, fromId: PlayerId, toId: PlayerId): Promise<CardId> {
+    const moveFrom = room.getPlayerById(fromId);
+    const moveTo = room.getPlayerById(toId);
+    const canMovedEquipCardIds: CardId[] = [];
+
+    const fromEquipArea = Precondition.exists(
+      moveFrom.getCardIds(PlayerCardsArea.EquipArea),
+      'Unable to get yongjin equips',
+    );
+    const banIds = room.getFlag<CardId[]>(user, this.Name);
+    canMovedEquipCardIds.push(
+      ...fromEquipArea.filter(id => room.canPlaceCardTo(id, moveTo.Id) && (banIds ? !banIds.includes(id) : true)),
+    );
+
+    const options: CardChoosingOptions = {
+      [PlayerCardsArea.EquipArea]: canMovedEquipCardIds,
+    };
+
+    const chooseCardEvent = {
+      fromId: user,
+      toId: user,
+      options,
+    };
+
+    room.notify(
+      GameEventIdentifiers.AskForChoosingCardFromPlayerEvent,
+      EventPacker.createUncancellableEvent<GameEventIdentifiers.AskForChoosingCardFromPlayerEvent>(chooseCardEvent),
+      user,
+    );
+
+    const response = await room.onReceivingAsyncResponseFrom(
+      GameEventIdentifiers.AskForChoosingCardFromPlayerEvent,
+      user,
+    );
+
+    response.selectedCard = response.selectedCard || canMovedEquipCardIds[0];
+
+    await room.moveCards({
+      movingCards: [{ card: response.selectedCard, fromArea: response.fromArea }],
+      moveReason: CardMoveReason.PassiveMove,
+      toId: moveTo.Id,
+      fromId: moveFrom.Id,
+      toArea: response.fromArea!,
+      proposer: chooseCardEvent.fromId,
+      movedByReason: this.Name,
+    });
+
+    return response.selectedCard;
+  }
+
+  public async onEffect(room: Room, event: ServerEventFinder<GameEventIdentifiers.SkillEffectEvent>): Promise<boolean> {
+    const { fromId, toIds } = event;
+
+    let banId = await this.yongJinMove(room, fromId, toIds![0], toIds![1]);
+    room.setFlag<CardId[]>(fromId, this.Name, [banId]);
+
+    for (let i = 0; i < 2; i++) {
+      const skillUseEvent = {
+        invokeSkillNames: [YongJinMove.Name],
+        toId: fromId,
+        conversation: TranslationPack.translationJsonPatcher(
+          '{0}: please choose two target to move their equipment',
+          this.Name,
+        ).extract(),
+      };
+
+      room.notify(GameEventIdentifiers.AskForSkillUseEvent, skillUseEvent, fromId);
+
+      const { toIds } = await room.onReceivingAsyncResponseFrom(GameEventIdentifiers.AskForSkillUseEvent, fromId);
+
+      if (!toIds) {
+        break;
+      }
+
+      banId = await this.yongJinMove(room, fromId, toIds[0], toIds[1]);
+      const banIds = room.getFlag<CardId[]>(fromId, this.Name) || [];
+
+      banIds.push(banId);
+      room.setFlag<CardId[]>(fromId, this.Name, banIds);
+    }
+
+    room.removeFlag(fromId, this.Name);
+
+    return true;
+  }
+}
+
+@ShadowSkill
+@CommonSkill({ name: 'yongjin_move', description: 'yongjin_move_description' })
+export class YongJinMove extends TriggerSkill {
+  public isTriggerable(): boolean {
+    return false;
+  }
+
+  public canUse(): boolean {
+    return false;
+  }
+
+  public numberOfTargets(): number {
+    return 2;
+  }
+
+  public isAvailableTarget(
+    owner: PlayerId,
+    room: Room,
+    target: PlayerId,
+    selectedCards: CardId[],
+    selectedTargets: PlayerId[],
+  ): boolean {
+    const to = room.getPlayerById(target);
+    const equipCardIds = to.getCardIds(PlayerCardsArea.EquipArea);
+
+    if (selectedTargets.length === 0) {
+      return equipCardIds.length > 0;
+    } else if (selectedTargets.length === 1) {
+      const from = room.getPlayerById(selectedTargets[0]);
+      const banIds = room.getFlag<CardId[]>(owner, YongJin.Name);
+
+      const fromEquipArea = from.getCardIds(PlayerCardsArea.EquipArea);
+
+      return (
+        fromEquipArea.find(id => {
+          return room.canPlaceCardTo(id, target) && (banIds ? !banIds.includes(id) : true);
+        }) !== undefined
+      );
+    }
+
+    return false;
+  }
+
+  public nominateForwardTarget(targets?: PlayerId[]) {
+    return [targets![0]];
+  }
+
+  public async onTrigger(): Promise<boolean> {
+    return true;
+  }
+
+  public async onEffect(): Promise<boolean> {
+    return true;
+  }
+}

--- a/src/core/skills/index.ts
+++ b/src/core/skills/index.ts
@@ -114,6 +114,7 @@ export { BuQu, BuQuShadow } from './characters/wind/buqu';
 export { FenJi } from './characters/wind/fenji';
 export { HongYan, HongYanShadow } from './characters/wind/hongyan';
 export { TianXiang } from './characters/wind/tianxiang';
+export { PiaoLing } from './characters/wind/piaoling';
 export { GuHuo, GuHuoShadow } from './characters/wind/guhuo';
 export { ChanYuan } from './characters/wind/chanyuan';
 export { LieGong, LieGongDamage, LieGongShadow } from './characters/wind/liegong';

--- a/src/core/skills/index.ts
+++ b/src/core/skills/index.ts
@@ -230,7 +230,8 @@ export { JueQing } from './characters/yijiang2011/jueqing';
 export { ShangShi } from './characters/yijiang2011/shangshi';
 export { GanLu } from './characters/yijiang2011/ganlu';
 export { BuYi } from './characters/yijiang2011/buyi';
-export { XuanFeng, XuanFengMove, XuanFengDrop } from './characters/yijiang2011/xuanfeng';
+export { XuanFeng } from './characters/yijiang2011/xuanfeng';
+export { YongJin, YongJinMove } from './characters/yijiang2011/yongjin';
 
 export { QiCe } from './characters/yijiang2012/qice';
 export { ZhiYu } from './characters/yijiang2012/zhiyu';

--- a/src/ui/platforms/desktop/src/languages/zh_CN/translations/standard.ts
+++ b/src/ui/platforms/desktop/src/languages/zh_CN/translations/standard.ts
@@ -326,20 +326,23 @@ export const skillDescriptions: Word[] = [
     source: 'yaowu_description',
     target: '<b>锁定技</b>，当你受到伤害时，若造成伤害的牌：为红色，伤害来源摸一张牌；不为红色，你摸一张牌。',
   },
-  { source: 'wangzun_description', target: '主公的准备阶段开始时，你可以摸一张牌，并令其本回合内手牌上限-1。' },
+  {
+    source: 'wangzun_description',
+    target: '锁定技，体力值大于你的角色的准备阶段开始时，你摸一张牌，若其为主公，改为你摸两张牌且其本回合手牌上限-1。',
+  },
   {
     source: 'tongji_description',
     target:
-      '<b>锁定技</b>，若你的手牌数大于你的体力值，则攻击范围内含有你的角色使用【杀】，不能指定除你外的角色为目标。',
+      '当其他角色成为【杀】的目标时，若你处于其攻击范围内且你不为此牌的使用者及目标，其可以弃置一张牌，将此【杀】转移给你。',
   },
   {
     source: 'yicong_description',
     target:
-      '<b>锁定技</b>，若你的体力值大于2，你计算与其他角色的距离-1；若你的体力值不大于2，其他角色计算与你的距离+1。',
+      '<b>锁定技</b>，你计算与其他角色的距离-1；若你的体力值不大于2，其他角色计算与你的距离+1。',
   },
   {
     source: 'qiaomeng_description',
-    target: '当你使用黑色【杀】对一名角色造成伤害后，你可弃置其装备区里的一张牌。若此牌为坐骑牌，你获得之。',
+    target: '当你使用【杀】对一名角色造成伤害后，你可弃置其区域内的一张牌。若此牌为坐骑牌，你获得之。',
   },
   { source: 'jijie_description', target: '出牌阶段限一次，你可以观看牌堆底一张牌，然后交给一名角色。' },
   { source: 'jiyuan_description', target: '当一名角色进入濒死状态或你交给一名其他角色牌时，你可以令其摸一张牌。' },
@@ -355,5 +358,17 @@ export const skillDescriptions: Word[] = [
     source: 'jianyan_description',
     target:
       '出牌阶段限一次，你可以声明一种牌的类别或颜色，然后亮出牌堆中第一张符合你声明的牌，并将之交给一名男性角色。',
+  },
+];
+
+export const promptDescriptions: Word[] = [
+  {
+    source: '{0}: do you want to discard 1 card to transfer the target of {1} to {2}',
+    target: '{0}：你可以弃置一张牌将此{1}转移给 {2}',
+  },
+
+  {
+    source: '{0} used skill {1}, transfer the target of {1} to {2}',
+    target: '{0} 使用了技能【{1}】，将{1}的目标转移给 {2}',
   },
 ];

--- a/src/ui/platforms/desktop/src/languages/zh_CN/translations/wind.ts
+++ b/src/ui/platforms/desktop/src/languages/zh_CN/translations/wind.ts
@@ -22,6 +22,7 @@ export const characterDictionary: Word[] = [
   { source: 'tianxiang', target: '天香' },
   { source: 'hongyan', target: '红颜' },
   { source: '#hongyan', target: '红颜' },
+  { source: 'piaoling', target: '飘零' },
 
   { source: 'zhoutai', target: '周泰' },
   { source: 'buqu', target: '不屈' },
@@ -73,12 +74,17 @@ export const skillDescriptions: Word[] = [
   {
     source: 'tianxiang_description',
     target:
-      '当你受到伤害时，你可以弃置一张红桃手牌，防止此伤害并选择一名其他角色，然后你选择一项：1.令其受到1点伤害，然后摸X张牌（X为其已损失体力值且至多为5）；2.令其失去1点体力，然后其获得你弃置的牌。',
+      '当你受到伤害时，你可以弃置一张红桃牌，防止此伤害并选择一名其他角色，然后你选择一项：1.令其受到1点伤害，然后摸X张牌（X为其已损失体力值且至多为5）；2.令其失去1点体力，然后其获得你弃置的牌。',
   },
   {
     source: 'hongyan_description',
     target:
-      '<b>锁定技</b>，你的黑桃牌或你的黑桃判定牌的花色视为红桃；当你于回合外失去红桃牌时，若你的手牌小于体力值，你摸一张牌。',
+      '<b>锁定技</b>，你的黑桃牌或你的黑桃判定牌的花色视为红桃；若你的装备区里有红桃牌，你的手牌上限等于X（X为你的体力上限）。',
+  },
+  {
+    source: 'piaoling_description',
+    target:
+      '结束阶段开始时，你可以判定，若结果为红桃，你选择一项：1.将判定牌交给一名角色，若其为你，你弃置一张牌；2.将判定牌置于牌堆顶。',
   },
   {
     source: 'buqu_description',

--- a/src/ui/platforms/desktop/src/languages/zh_CN/translations/wind.ts
+++ b/src/ui/platforms/desktop/src/languages/zh_CN/translations/wind.ts
@@ -117,4 +117,6 @@ export const skillDescriptions: Word[] = [
     source: 'chanyuan_description',
     target: '<b>锁定技</b>，你不能质疑“蛊惑”；若你的体力值小于等于1，则你的其他技能失效。',
   },
+  { source: '#piaoling-select', target: '请选择：1. 将判定牌置于牌堆顶。2. 交给一名角色' },
+  { source: 'piaoling: select a player to obtain the judge card', target: '飘零：选择一名角色获得此判定牌' },
 ];

--- a/src/ui/platforms/desktop/src/languages/zh_CN/translations/yijiang2011.ts
+++ b/src/ui/platforms/desktop/src/languages/zh_CN/translations/yijiang2011.ts
@@ -83,7 +83,7 @@ export const skillDescriptions: Word[] = [
 
   {
     source: 'sanyao_description',
-    target: '出牌阶段每项限一次，你可以弃置一张牌，并选择一项：1.指定体力值最高的一名角色；2.指定手牌数最多的一名角色，对你所选的角色造成1点伤害。',
+    target: '出牌阶段每项限一次，你可以弃置一张牌，并选择一项：1.指定体力值最高的一名角色；2.指定手牌数最多的一名角色。对你所选的角色造成1点伤害。',
   },
   {
     source: 'zhiman_description',
@@ -136,7 +136,7 @@ export const skillDescriptions: Word[] = [
   {
     source: 'yongjin_description',
     target:
-      '<b>限定技</b>，出牌阶段，你可以依次移动场上一至三张装备区里的不同的牌。',
+      '<b>限定技</b>，出牌阶段，你可以依次移动场上一至三张不同的装备牌。',
   },
 
   {

--- a/src/ui/platforms/desktop/src/languages/zh_CN/translations/yijiang2011.ts
+++ b/src/ui/platforms/desktop/src/languages/zh_CN/translations/yijiang2011.ts
@@ -82,7 +82,7 @@ export const skillDescriptions: Word[] = [
 
   {
     source: 'sanyao_description',
-    target: '出牌阶段限一次，你可以弃置至少一张牌，并选择等量名除你外体力最高的角色，你对这些角色各造成1点伤害。',
+    target: '出牌阶段每项限一次，你可以弃置一张牌，并选择一项：1.指定体力值最高的一名角色；2.指定手牌数最多的一名角色，对你所选的角色造成1点伤害。',
   },
   {
     source: 'zhiman_description',
@@ -171,6 +171,14 @@ export const promptDescriptions: Word[] = [
     source: '{0}: you need to give a handcard to {1}',
     target: '{0}：你需交给 {1} 一张手牌',
   },
+
+  {
+    source: 'please choose sanyao options',
+    target: '<b>散谣</b>：请选择消耗项',
+  },
+  { source: 'sanyao:hp', target: '体力值' },
+  { source: 'sanyao:handNum', target: '手牌数' },
+
   {
     source: '{0}: do you want to prevent the damage to {1} to pick one card in areas?',
     target: '{0}：你可以防止对 {1} 造成的伤害，然后获得其区域里的一张牌',

--- a/src/ui/platforms/desktop/src/languages/zh_CN/translations/yijiang2011.ts
+++ b/src/ui/platforms/desktop/src/languages/zh_CN/translations/yijiang2011.ts
@@ -37,6 +37,7 @@ export const characterDictionary: Word[] = [
 
   { source: 'lingtong', target: '凌统' },
   { source: 'xuanfeng', target: '旋风' },
+  { source: 'yongjin', target: '勇进' },
 
   { source: 'chengong', target: '陈宫' },
   { source: 'mingce', target: '明策' },
@@ -130,7 +131,12 @@ export const skillDescriptions: Word[] = [
   {
     source: 'xuanfeng_description',
     target:
-      '若你于弃牌阶段内弃置过至少两张手牌，或当你失去装备区里的牌后，你可以选择一项：1.依次弃置其他角色的共计一至两张牌；2.将一名其他角色装备区里的牌置入另一名其他角色的装备区。',
+      '若你于弃牌阶段内弃置过至少两张手牌，或当你失去装备区里的牌后，你可以依次弃置其他角色的共计一至两张牌，然后你可以对其中一名角色造成1点伤害。',
+  },
+  {
+    source: 'yongjin_description',
+    target:
+      '<b>限定技</b>，出牌阶段，你可以依次移动场上一至三张装备区里的不同的牌。',
   },
 
   {
@@ -225,16 +231,21 @@ export const promptDescriptions: Word[] = [
     source: 'xianzhen: do you want to add {0} as targets of {1}?',
     target: '陷阵：你可以令 {0} 也成为 {1} 的目标',
   },
-  { source: 'xuanfeng:move', target: '移动装备' },
-  { source: 'xuanfeng:drop', target: '弃置牌' },
+
+  {
+    source: '{0}: do you want to choose a target to drop a card?',
+    target: '{0}：你可以弃置一名角色的一张牌',
+  },
+  {
+    source: '{0}: do you want to choose a XuanFeng target to deal 1 damage?',
+    target: '{0}：你可以选择其中一名角色，对其造成1点伤害',
+  },
+
   {
     source: '{0}: please choose two target to move their equipment',
-    target: '{0}：请依次选择两名其他角色，先选角色装备区里的牌将被移至后选角色',
+    target: '{0}：你可以依次选择两名角色，先选角色装备区里的牌将被移至后选角色',
   },
-  {
-    source: '{0}: please choose a target to drop card',
-    target: '{0}：请选择一名角色并弃置其一张牌',
-  },
+
   {
     source: '{0}: do you want to draw {1} cards?',
     target: '{0}: 是否摸 {1} 张牌?',


### PR DESCRIPTION
以下为本次修改的技能（修改后描述）：
>【散谣】出牌阶段每项各限一次，你可以弃置一张牌，并选择一项：1.指定手牌数最多的一名角色；2.指定体力值最高的一名角色。你对你指定的角色造成1点伤害。

>【旋风】当你失去装备区里的牌后，或当你于弃牌阶段内弃置至少两张手牌后，你可以依次弃置一至两名角色共计两张牌，然后你可对其中一名角色造成1点伤害。

>【天香】（弃置一张红桃手牌→弃置一张红桃牌）
>【红颜】（增加描述“若你的装备区里有红桃牌，则你的手牌上限等同于体力上限”）

>【妄尊】锁定技，体力值大于你的角色的准备阶段开始时，你摸一张牌，若其为主公，改为你摸两张牌且其本回合手牌上限-1。
>【同疾】当其他角色成为【杀】的目标时，若你处于其攻击范围内且你不为此【杀】的使用者及目标，其可以弃置一张牌，将此【杀】转移给你。

以下为本次新增的技能：
## **小乔：**
>【飘零】结束阶段开始时，你可以判定，若结果为红桃，你选择一项：1.将此判定牌交给一名角色，若为你，你弃置一张牌；2.将此判定牌置于牌堆顶。
## **凌统：**
>【勇进】限定技，出牌阶段，你可以依次移动场上一至三张不同的装备牌。