### PR TITLE
custom flag name & change the time of unhooking

### DIFF
--- a/src/core/event/event.server.ts
+++ b/src/core/event/event.server.ts
@@ -24,7 +24,7 @@ export interface ServerEvent extends EventUtilities {
     name: string;
     value: any;
     to: PlayerId;
-    invisible: boolean;
+    tagName?: string;
   };
   [GameEventIdentifiers.RemoveFlagEvent]: {
     name: string;

--- a/src/core/player/player.client.ts
+++ b/src/core/player/player.client.ts
@@ -5,7 +5,7 @@ import { PlayerCards, PlayerCardsArea, PlayerCardsOutside, PlayerId } from './pl
 
 export class ClientPlayer extends Player {
   private visibleOutsideAreas: string[] = [];
-  private visiblePlayerTags: string[] = [];
+  private visiblePlayerTags: { [name: string]: string } = {};
 
   constructor(
     protected playerId: PlayerId,
@@ -19,19 +19,19 @@ export class ClientPlayer extends Player {
     super(playerCards, playerCharacterId);
   }
 
-  setFlag<T>(name: string, value: T, invisible?: boolean): T {
-    if (!invisible && !this.visiblePlayerTags.includes(name)) {
-      this.visiblePlayerTags.push(name);
+  setFlag<T>(name: string, value: T, tagName?: string): T {
+    if (tagName && this.visiblePlayerTags[name] !== tagName) {
+      this.visiblePlayerTags[name] = tagName;
     }
 
     return super.setFlag(name, value);
   }
   public clearFlags() {
-    this.visiblePlayerTags = [];
+    this.visiblePlayerTags = {};
     super.clearFlags();
   }
   removeFlag(name: string) {
-    this.visiblePlayerTags = this.visiblePlayerTags.filter(tag => tag !== name);
+    delete this.visiblePlayerTags[name];
     super.removeFlag(name);
   }
 
@@ -48,7 +48,7 @@ export class ClientPlayer extends Player {
     return this.visibleOutsideAreas.includes(areaName);
   }
   getAllVisibleTags() {
-    return this.visiblePlayerTags;
+    return Object.values(this.visiblePlayerTags);
   }
 
   setHuaShenInfo(info: HuaShenInfo) {
@@ -57,7 +57,7 @@ export class ClientPlayer extends Player {
         TranslationPack.translationJsonPatcher('huashen skill:{0}', this.huashenInfo.skillName).toString(),
       );
     }
-    this.setFlag(TranslationPack.translationJsonPatcher('huashen skill:{0}', info.skillName).toString(), true, false);
+    this.setFlag(TranslationPack.translationJsonPatcher('huashen skill:{0}', info.skillName).toString(), true);
     super.setHuaShenInfo(info);
   }
 

--- a/src/core/room/room.server.ts
+++ b/src/core/room/room.server.ts
@@ -455,10 +455,10 @@ export class ServerRoom extends Room<WorkPlace.Server> {
 
     this.hookedSkills = this.hookedSkills.filter(({ skill, player }) => {
       const hookedSkill = skill as unknown as OnDefineReleaseTiming;
-      if (hookedSkill.afterLosingSkill && hookedSkill.afterLosingSkill(this, player.Id)) {
+      if (hookedSkill.afterLosingSkill && hookedSkill.afterLosingSkill(this, player.Id, content, stage)) {
         return false;
       }
-      if (hookedSkill.afterDead && hookedSkill.afterDead(this, player.Id)) {
+      if (hookedSkill.afterDead && hookedSkill.afterDead(this, player.Id, content, stage)) {
         return false;
       }
       return true;
@@ -1602,12 +1602,12 @@ export class ServerRoom extends Room<WorkPlace.Server> {
     });
     super.removeFlag(player, name);
   }
-  public setFlag<T>(player: PlayerId, name: string, value: T, playerTag?: boolean): T {
+  public setFlag<T>(player: PlayerId, name: string, value: T, tagName?: string): T {
     this.broadcast(GameEventIdentifiers.SetFlagEvent, {
       to: player,
       value,
       name,
-      invisible: !playerTag,
+      tagName,
     });
     return super.setFlag(player, name, value);
   }

--- a/src/core/room/room.ts
+++ b/src/core/room/room.ts
@@ -530,7 +530,7 @@ export abstract class Room<T extends WorkPlace = WorkPlace> {
   public removeFlag(player: PlayerId, name: string) {
     this.getPlayerById(player).removeFlag(name);
   }
-  public setFlag<T>(player: PlayerId, name: string, value: T, invisible?: boolean): T {
+  public setFlag<T>(player: PlayerId, name: string, value: T, tagName?: string): T {
     return this.getPlayerById(player).setFlag(name, value);
   }
   public getFlag<T>(player: PlayerId, name: string): T {

--- a/src/core/skills/characters/fire/cangzhuo.ts
+++ b/src/core/skills/characters/fire/cangzhuo.ts
@@ -44,8 +44,13 @@ export class CangZhuo extends TriggerSkill {
 @ShadowSkill
 @CompulsorySkill({ name: CangZhuo.GeneralName, description: CangZhuo.Description })
 export class CangZhuoShadow extends TriggerSkill implements OnDefineReleaseTiming {
-  afterLosingSkill(room: Room, playerId: PlayerId) {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   public isTriggerable(

--- a/src/core/skills/characters/fire/qiangxi.ts
+++ b/src/core/skills/characters/fire/qiangxi.ts
@@ -49,7 +49,7 @@ export class QiangXi extends ActiveSkill {
   async onEffect(room: Room, skillUseEvent: ServerEventFinder<GameEventIdentifiers.SkillEffectEvent>) {
     const { fromId, toIds, cardIds } = skillUseEvent;
     room.setFlag<boolean>(fromId, QiangXi.exUse, true);
-    room.setFlag<boolean>(toIds![0], this.Name, true, false);
+    room.setFlag<boolean>(toIds![0], this.Name, true);
 
     if (cardIds && cardIds.length > 0) {
       await room.dropCards(CardMoveReason.SelfDrop, cardIds, fromId, fromId, this.Name);

--- a/src/core/skills/characters/fire/shuangxiong.ts
+++ b/src/core/skills/characters/fire/shuangxiong.ts
@@ -24,8 +24,13 @@ export class ShuangXiong extends ViewAsSkill implements OnDefineReleaseTiming {
   public static readonly Red = 'shuangxiong_red';
   public static readonly Black = 'shuangxiong_black';
 
-  afterLosingSkill(room: Room, playerId: PlayerId) {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   public canViewAs(): string[] {
@@ -222,8 +227,8 @@ export class ShuangXiongShadow extends TriggerSkill {
       });
 
       const chosenCard = Sanguosha.getCardById(chosenOne);
-      chosenCard.isRed() && room.setFlag<boolean>(fromId, ShuangXiong.Red, true, true);
-      chosenCard.isBlack() && room.setFlag<boolean>(fromId, ShuangXiong.Black, true, true);
+      chosenCard.isRed() && room.setFlag<boolean>(fromId, ShuangXiong.Red, true, ShuangXiong.Red);
+      chosenCard.isBlack() && room.setFlag<boolean>(fromId, ShuangXiong.Black, true, ShuangXiong.Red);
       await room.moveCards({
         movingCards: displayCards
           .filter(id => id !== chosenOne)
@@ -255,8 +260,13 @@ export class ShuangXiongShadow extends TriggerSkill {
 @ShadowSkill
 @CommonSkill({ name: ShuangXiongShadow.Name, description: ShuangXiongShadow.Description })
 export class ShuangXiongRemove extends TriggerSkill implements OnDefineReleaseTiming {
-  public afterLosingSkill(room: Room): boolean {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   public isAutoTrigger(): boolean {

--- a/src/core/skills/characters/fire/tianyi.ts
+++ b/src/core/skills/characters/fire/tianyi.ts
@@ -3,7 +3,7 @@ import { CardId } from 'core/cards/libs/card_props';
 import { GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
 import { Sanguosha } from 'core/game/engine';
 import { INFINITE_DISTANCE } from 'core/game/game_props';
-import { PhaseChangeStage, PlayerPhase } from 'core/game/stage_processor';
+import { AllStage, PhaseChangeStage, PlayerPhase } from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
 import { PlayerCardsArea, PlayerId } from 'core/player/player_props';
 import { Room } from 'core/room/room';
@@ -57,9 +57,9 @@ export class TianYi extends ActiveSkill {
     }
 
     if (pindianRecord[0].winner === fromId) {
-      room.setFlag<boolean>(fromId, TianYi.Win, true, true);
+      room.setFlag<boolean>(fromId, TianYi.Win, true, TianYi.Win);
     } else {
-      room.setFlag<boolean>(fromId, TianYi.Lose, true, true);
+      room.setFlag<boolean>(fromId, TianYi.Lose, true, TianYi.Lose);
     }
 
     return true;
@@ -69,8 +69,13 @@ export class TianYi extends ActiveSkill {
 @ShadowSkill
 @CommonSkill({ name: TianYi.Name, description: TianYi.Description })
 export class TianYiRemove extends TriggerSkill implements OnDefineReleaseTiming {
-  public afterLosingSkill(room: Room): boolean {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   public isAutoTrigger(): boolean {
@@ -119,8 +124,13 @@ export class TianYiRemove extends TriggerSkill implements OnDefineReleaseTiming 
 @ShadowSkill
 @CommonSkill({ name: TianYiRemove.Name, description: TianYiRemove.Description })
 export class TianYiExtra extends RulesBreakerSkill implements OnDefineReleaseTiming {
-  public afterLosingSkill(room: Room, playerId: PlayerId): boolean {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   public breakCardUsableTargets(cardId: CardId | CardMatcher, room: Room, owner: Player): number {
@@ -177,8 +187,13 @@ export class TianYiExtra extends RulesBreakerSkill implements OnDefineReleaseTim
 @ShadowSkill
 @CommonSkill({ name: TianYiExtra.Name, description: TianYiExtra.Description })
 export class TianYiBlock extends FilterSkill implements OnDefineReleaseTiming {
-  public afterLosingSkill(room: Room): boolean {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   public canUseCard(cardId: CardId | CardMatcher, room: Room, owner: PlayerId): boolean {

--- a/src/core/skills/characters/forest/duanliang.ts
+++ b/src/core/skills/characters/forest/duanliang.ts
@@ -4,11 +4,10 @@ import { CardId } from 'core/cards/libs/card_props';
 import { Slash } from 'core/cards/standard/slash';
 import { Sanguosha } from 'core/game/engine';
 import { INFINITE_DISTANCE } from 'core/game/game_props';
-import { PlayerPhase } from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
-import { PlayerCardsArea, PlayerId } from 'core/player/player_props';
+import { PlayerCardsArea } from 'core/player/player_props';
 import { Room } from 'core/room/room';
-import { CommonSkill, OnDefineReleaseTiming, RulesBreakerSkill, ShadowSkill, ViewAsSkill } from 'core/skills/skill';
+import { CommonSkill, RulesBreakerSkill, ShadowSkill, ViewAsSkill } from 'core/skills/skill';
 
 @CommonSkill({ name: 'duanliang', description: 'duanliang_description' })
 export class DuanLiang extends ViewAsSkill {
@@ -53,11 +52,7 @@ export class DuanLiang extends ViewAsSkill {
 
 @ShadowSkill
 @CommonSkill({ name: DuanLiang.Name, description: DuanLiang.Description })
-export class DuanLiangShadow extends RulesBreakerSkill implements OnDefineReleaseTiming {
-  afterLosingSkill(room: Room, playerId: PlayerId) {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
-  }
-
+export class DuanLiangShadow extends RulesBreakerSkill {
   breakCardUsableDistanceTo(cardId: CardId | CardMatcher, room: Room, owner: Player, target: Player) {
     if (owner.getCardIds(PlayerCardsArea.HandArea).length > target.getCardIds(PlayerCardsArea.HandArea).length) {
       return 0;

--- a/src/core/skills/characters/forest/jiuchi.ts
+++ b/src/core/skills/characters/forest/jiuchi.ts
@@ -94,7 +94,7 @@ export class JiuChiDrunk extends TriggerSkill implements OnDefineReleaseTiming {
   }
 
   public async onEffect(room: Room, event: ServerEventFinder<GameEventIdentifiers.SkillEffectEvent>): Promise<boolean> {
-    room.setFlag<boolean>(event.fromId, JiuChi.Used, true, true);
+    room.setFlag<boolean>(event.fromId, JiuChi.Used, true, JiuChi.Used);
 
     return true;
   }

--- a/src/core/skills/characters/forest/roulin.ts
+++ b/src/core/skills/characters/forest/roulin.ts
@@ -2,8 +2,9 @@ import { CardMatcher } from 'core/cards/libs/card_matcher';
 import { CharacterGender } from 'core/characters/character';
 import { EventPacker, GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
 import { Sanguosha } from 'core/game/engine';
-import { AimStage, AllStage, CardUseStage, PlayerPhase } from 'core/game/stage_processor';
+import { AimStage, AllStage, CardUseStage, PhaseChangeStage, PlayerPhase } from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
+import { PlayerId } from 'core/player/player_props';
 import { Room } from 'core/room/room';
 import { CompulsorySkill, OnDefineReleaseTiming, ShadowSkill, TriggerSkill } from 'core/skills/skill';
 import { TranslationPack } from 'core/translations/translation_json_tool';
@@ -55,8 +56,13 @@ export class RouLin extends TriggerSkill {
 @ShadowSkill
 @CompulsorySkill({ name: RouLin.GeneralName, description: RouLin.Description })
 export class RouLinShadow extends TriggerSkill implements OnDefineReleaseTiming {
-  afterLosingSkill(room: Room) {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseBegin && stage === PhaseChangeStage.AfterPhaseChanged;
   }
 
   public isTriggerable(event: ServerEventFinder<GameEventIdentifiers.CardUseEvent>, stage?: AllStage): boolean {

--- a/src/core/skills/characters/god/dawu.ts
+++ b/src/core/skills/characters/god/dawu.ts
@@ -101,8 +101,13 @@ export class DaWu extends TriggerSkill implements OnDefineReleaseTiming {
 @ShadowSkill
 @CommonSkill({ name: DaWu.Name, description: DaWu.Description })
 export class DaWuShadow extends TriggerSkill implements OnDefineReleaseTiming {
-  public afterLosingSkill(room: Room, owner: PlayerId): boolean {
-    return room.CurrentPlayerPhase === PlayerPhase.PrepareStage;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseBegin && stage === PhaseChangeStage.AfterPhaseChanged;
   }
 
   public isFlaggedSkill(room: Room, event: ServerEventFinder<GameEventIdentifiers>, stage?: AllStage): boolean {
@@ -118,7 +123,7 @@ export class DaWuShadow extends TriggerSkill implements OnDefineReleaseTiming {
   }
 
   public isTriggerable(event: ServerEventFinder<GameEventIdentifiers>, stage?: AllStage): boolean {
-    return stage === DamageEffectStage.DamagedEffect || stage === PhaseChangeStage.BeforePhaseChange;
+    return stage === DamageEffectStage.DamagedEffect || stage === PhaseChangeStage.AfterPhaseChanged;
   }
 
   public canUse(room: Room, owner: Player, event: ServerEventFinder<GameEventIdentifiers>): boolean {
@@ -129,7 +134,7 @@ export class DaWuShadow extends TriggerSkill implements OnDefineReleaseTiming {
     } else if (identifier === GameEventIdentifiers.PhaseChangeEvent) {
       const phaseChangeEvent = event as ServerEventFinder<GameEventIdentifiers.PhaseChangeEvent>;
       return (
-        phaseChangeEvent.to === PlayerPhase.PrepareStage &&
+        phaseChangeEvent.to === PlayerPhase.PhaseBegin &&
         phaseChangeEvent.toPlayer === owner.Id &&
         !!room.getAlivePlayersFrom().find(player => player.getMark(MarkEnum.DaWu) > 0)
       );

--- a/src/core/skills/characters/god/kuangfeng.ts
+++ b/src/core/skills/characters/god/kuangfeng.ts
@@ -86,8 +86,13 @@ export class KuangFeng extends TriggerSkill implements OnDefineReleaseTiming {
 @ShadowSkill
 @CommonSkill({ name: KuangFeng.Name, description: KuangFeng.Description })
 export class KuangFengShadow extends TriggerSkill implements OnDefineReleaseTiming {
-  public afterLosingSkill(room: Room): boolean {
-    return room.CurrentPlayerPhase === PlayerPhase.PrepareStage;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseBegin && stage === PhaseChangeStage.AfterPhaseChanged;
   }
 
   public isFlaggedSkill(room: Room, event: ServerEventFinder<GameEventIdentifiers>, stage?: AllStage): boolean {
@@ -99,7 +104,7 @@ export class KuangFengShadow extends TriggerSkill implements OnDefineReleaseTimi
   }
 
   public isTriggerable(event: ServerEventFinder<GameEventIdentifiers>, stage?: AllStage): boolean {
-    return stage === DamageEffectStage.DamagedEffect || stage === PhaseChangeStage.BeforePhaseChange;
+    return stage === DamageEffectStage.DamagedEffect || stage === PhaseChangeStage.AfterPhaseChanged;
   }
 
   public canUse(room: Room, owner: Player, event: ServerEventFinder<GameEventIdentifiers>): boolean {
@@ -110,7 +115,7 @@ export class KuangFengShadow extends TriggerSkill implements OnDefineReleaseTimi
     } else if (identifier === GameEventIdentifiers.PhaseChangeEvent) {
       const phaseChangeEvent = event as ServerEventFinder<GameEventIdentifiers.PhaseChangeEvent>;
       return (
-        phaseChangeEvent.to === PlayerPhase.PrepareStage &&
+        phaseChangeEvent.to === PlayerPhase.PhaseBegin &&
         phaseChangeEvent.toPlayer === owner.Id &&
         !!room.getAlivePlayersFrom().find(player => player.getMark(MarkEnum.KuangFeng) > 0)
       );

--- a/src/core/skills/characters/god/wuqian.ts
+++ b/src/core/skills/characters/god/wuqian.ts
@@ -1,5 +1,11 @@
 import { GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
-import { AllStage, PhaseStageChangeStage, PlayerPhaseStages } from 'core/game/stage_processor';
+import {
+  AllStage,
+  PhaseChangeStage,
+  PhaseStageChangeStage,
+  PlayerPhase,
+  PlayerPhaseStages,
+} from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
 import { PlayerId } from 'core/player/player_props';
 import { Room } from 'core/room/room';
@@ -52,8 +58,13 @@ export class WuQian extends ActiveSkill {
 @ShadowSkill
 @CompulsorySkill({ name: WuQian.GeneralName, description: WuQian.Description })
 export class WuQianShadow extends TriggerSkill implements OnDefineReleaseTiming {
-  public afterLosingSkill(room: Room): boolean {
-    return room.CurrentPlayerStage === PlayerPhaseStages.PhaseFinishEnd;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   public afterDead(): boolean {

--- a/src/core/skills/characters/mountain/duanchang.ts
+++ b/src/core/skills/characters/mountain/duanchang.ts
@@ -34,7 +34,7 @@ export class DuanChang extends TriggerSkill {
         .map(skill => skill.Name),
       true,
     );
-    room.setFlag<boolean>(killedBy!, this.GeneralName, true, true);
+    room.setFlag<boolean>(killedBy!, this.GeneralName, true, this.GeneralName);
     return true;
   }
 }

--- a/src/core/skills/characters/mountain/sishu.ts
+++ b/src/core/skills/characters/mountain/sishu.ts
@@ -37,7 +37,7 @@ export class SiShu extends TriggerSkill {
     if (room.getFlag(toId, this.Name) === true) {
       room.removeFlag(toId, this.Name);
     } else {
-      room.setFlag<boolean>(toIds![0], this.Name, true, true);
+      room.setFlag<boolean>(toIds![0], this.Name, true, this.Name);
     }
 
     return true;

--- a/src/core/skills/characters/standard/fanjian.ts
+++ b/src/core/skills/characters/standard/fanjian.ts
@@ -8,6 +8,7 @@ import {
   ServerEventFinder,
 } from 'core/event/event';
 import { Sanguosha } from 'core/game/engine';
+import { PlayerPhase } from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
 import { PlayerCardsArea, PlayerId } from 'core/player/player_props';
 import { Room } from 'core/room/room';
@@ -19,6 +20,10 @@ import { TranslationPack } from 'core/translations/translation_json_tool';
 export class FanJian extends ActiveSkill {
   public canUse(room: Room, owner: Player) {
     return !owner.hasUsedSkill(this.Name);
+  }
+
+  public isRefreshAt(room: Room, owner: Player, phase: PlayerPhase): boolean {
+    return phase === PlayerPhase.PlayCardStage;
   }
 
   public numberOfTargets() {

--- a/src/core/skills/characters/standard/gongxin.ts
+++ b/src/core/skills/characters/standard/gongxin.ts
@@ -8,6 +8,7 @@ import {
   GameEventIdentifiers,
   ServerEventFinder,
 } from 'core/event/event';
+import { PlayerPhase } from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
 import { PlayerCardsArea, PlayerId } from 'core/player/player_props';
 import { Room } from 'core/room/room';
@@ -18,6 +19,10 @@ import { TranslationPack } from 'core/translations/translation_json_tool';
 export class GongXin extends ActiveSkill {
   public canUse(room: Room, owner: Player) {
     return !owner.hasUsedSkill(this.Name);
+  }
+
+  public isRefreshAt(room: Room, owner: Player, phase: PlayerPhase): boolean {
+    return phase === PlayerPhase.PlayCardStage;
   }
 
   public numberOfTargets() {

--- a/src/core/skills/characters/standard/guose.ts
+++ b/src/core/skills/characters/standard/guose.ts
@@ -3,6 +3,7 @@ import { CardMatcher, CardMatcherProps } from 'core/cards/libs/card_matcher';
 import { CardId, CardSuit } from 'core/cards/libs/card_props';
 import { CardMoveReason, GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
 import { Sanguosha } from 'core/game/engine';
+import { PlayerPhase } from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
 import { PlayerCardsArea, PlayerId } from 'core/player/player_props';
 import { Room } from 'core/room/room';
@@ -12,6 +13,10 @@ import { ActiveSkill, CommonSkill } from 'core/skills/skill';
 export class GuoSe extends ActiveSkill {
   public canUse(room: Room, owner: Player) {
     return !owner.hasUsedSkill(this.Name);
+  }
+  
+  public isRefreshAt(room: Room, owner: Player, phase: PlayerPhase): boolean {
+    return phase === PlayerPhase.PlayCardStage;
   }
 
   public cardFilter(room: Room, owner: Player, cards: CardId[]): boolean {

--- a/src/core/skills/characters/standard/jiangchi.ts
+++ b/src/core/skills/characters/standard/jiangchi.ts
@@ -3,7 +3,13 @@ import { CardId } from 'core/cards/libs/card_props';
 import { CardMoveReason, EventPacker, GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
 import { Sanguosha } from 'core/game/engine';
 import { INFINITE_DISTANCE } from 'core/game/game_props';
-import { AllStage, PhaseStageChangeStage, PlayerPhase, PlayerPhaseStages } from 'core/game/stage_processor';
+import {
+  AllStage,
+  PhaseChangeStage,
+  PhaseStageChangeStage,
+  PlayerPhase,
+  PlayerPhaseStages,
+} from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
 import { PlayerCardsArea, PlayerId } from 'core/player/player_props';
 import { Room } from 'core/room/room';
@@ -101,8 +107,13 @@ export class JiangChi extends TriggerSkill {
 @ShadowSkill
 @CompulsorySkill({ name: JiangChi.Name, description: JiangChi.Description })
 export class JiangChiExtra extends RulesBreakerSkill implements OnDefineReleaseTiming {
-  public afterLosingSkill(room: Room, playerId: PlayerId): boolean {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   public breakCardUsableDistance(cardId: CardId | CardMatcher, room: Room, owner: Player): number {
@@ -147,8 +158,13 @@ export class JiangChiExtra extends RulesBreakerSkill implements OnDefineReleaseT
 @ShadowSkill
 @CompulsorySkill({ name: JiangChiExtra.Name, description: JiangChiExtra.Description })
 export class JiangChiBlock extends FilterSkill implements OnDefineReleaseTiming {
-  public afterLosingSkill(room: Room): boolean {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   public canUseCard(cardId: CardId | CardMatcher, room: Room, owner: PlayerId): boolean {
@@ -164,7 +180,16 @@ export class JiangChiBlock extends FilterSkill implements OnDefineReleaseTiming 
 
 @ShadowSkill
 @CompulsorySkill({ name: JiangChiBlock.Name, description: JiangChi.Description })
-export class JiangChiKeep extends TriggerSkill {
+export class JiangChiKeep extends TriggerSkill implements OnDefineReleaseTiming {
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
+  }
+
   public isTriggerable(event: ServerEventFinder<GameEventIdentifiers.AskForCardDropEvent>) {
     return EventPacker.getIdentifier(event) === GameEventIdentifiers.AskForCardDropEvent;
   }

--- a/src/core/skills/characters/standard/jianyan.ts
+++ b/src/core/skills/characters/standard/jianyan.ts
@@ -3,6 +3,7 @@ import { CardMatcher } from 'core/cards/libs/card_matcher';
 import { CardId, CardSuit } from 'core/cards/libs/card_props';
 import { CharacterGender } from 'core/characters/character';
 import { CardMoveArea, CardMoveReason, EventPacker, GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
+import { PlayerPhase } from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
 import { Room } from 'core/room/room';
 import { ActiveSkill, CommonSkill } from 'core/skills/skill';
@@ -12,6 +13,10 @@ import { TranslationPack } from 'core/translations/translation_json_tool';
 export class JianYan extends ActiveSkill {
   public canUse(room: Room, owner: Player): boolean {
     return !owner.hasUsedSkill(this.Name);
+  }
+
+  public isRefreshAt(room: Room, owner: Player, phase: PlayerPhase): boolean {
+    return phase === PlayerPhase.PlayCardStage;
   }
 
   public numberOfTargets() {

--- a/src/core/skills/characters/standard/jieyin.ts
+++ b/src/core/skills/characters/standard/jieyin.ts
@@ -11,6 +11,7 @@ import {
   ServerEventFinder,
 } from 'core/event/event';
 import { Sanguosha } from 'core/game/engine';
+import { PlayerPhase } from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
 import { PlayerCardsArea, PlayerId } from 'core/player/player_props';
 import { Room } from 'core/room/room';
@@ -20,6 +21,10 @@ import { ActiveSkill, CommonSkill } from 'core/skills/skill';
 export class JieYin extends ActiveSkill {
   public canUse(room: Room, owner: Player) {
     return !owner.hasUsedSkill(this.Name);
+  }
+
+  public isRefreshAt(room: Room, owner: Player, phase: PlayerPhase): boolean {
+    return phase === PlayerPhase.PlayCardStage;
   }
 
   public numberOfTargets() {

--- a/src/core/skills/characters/standard/jijie.ts
+++ b/src/core/skills/characters/standard/jijie.ts
@@ -1,4 +1,5 @@
 import { CardMoveArea, CardMoveReason, GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
+import { PlayerPhase } from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
 import { Room } from 'core/room/room';
 import { ActiveSkill, CommonSkill } from 'core/skills/skill';
@@ -7,6 +8,10 @@ import { ActiveSkill, CommonSkill } from 'core/skills/skill';
 export class JiJie extends ActiveSkill {
   public canUse(room: Room, owner: Player): boolean {
     return !owner.hasUsedSkill(this.Name);
+  }
+
+  public isRefreshAt(room: Room, owner: Player, phase: PlayerPhase): boolean {
+    return phase === PlayerPhase.PlayCardStage;
   }
 
   public numberOfTargets() {

--- a/src/core/skills/characters/standard/luoyi.ts
+++ b/src/core/skills/characters/standard/luoyi.ts
@@ -100,7 +100,7 @@ export class LuoYi extends TriggerSkill {
           moveReason: CardMoveReason.ActivePrey,
         });
 
-        room.setFlag<boolean>(skillUseEvent.fromId, this.Name, true, true);
+        room.setFlag<boolean>(skillUseEvent.fromId, this.Name, true, this.Name);
       } else {
         luoyiObtain = [];
       }
@@ -123,8 +123,13 @@ export class LuoYi extends TriggerSkill {
 @ShadowSkill
 @CompulsorySkill({ name: LuoYi.GeneralName, description: LuoYi.Description })
 export class LuoYiShadow extends TriggerSkill implements OnDefineReleaseTiming {
-  afterLosingSkill(room: Room, playerId: PlayerId) {
-    return room.CurrentPlayer === room.getPlayerById(playerId) && room.CurrentPlayerPhase === PlayerPhase.PhaseBegin;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseBegin && stage === PhaseChangeStage.AfterPhaseChanged;
   }
 
   public getPriority() {

--- a/src/core/skills/characters/standard/paoxiao.ts
+++ b/src/core/skills/characters/standard/paoxiao.ts
@@ -39,7 +39,12 @@ export class PaoXiaoShadow extends TriggerSkill {
 
   async onEffect(room: Room, event: ServerEventFinder<GameEventIdentifiers.SkillEffectEvent>) {
     const baseDamage = room.getFlag<number>(event.fromId, this.GeneralName) || 0;
-    room.setFlag<number>(event.fromId, this.GeneralName, baseDamage + 1, true);
+    room.setFlag<number>(
+      event.fromId,
+      this.GeneralName,
+      baseDamage + 1,
+      TranslationPack.translationJsonPatcher('paoxiao DMG: {0}', baseDamage + 1).toString(),
+    );
 
     return true;
   }
@@ -48,8 +53,13 @@ export class PaoXiaoShadow extends TriggerSkill {
 @ShadowSkill
 @CompulsorySkill({ name: PaoXiaoShadow.Name, description: PaoXiaoShadow.Description })
 export class PaoXiaoRemove extends TriggerSkill implements OnDefineReleaseTiming {
-  afterLosingSkill(room: Room, playerId: PlayerId) {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   public isTriggerable(

--- a/src/core/skills/characters/standard/qianxun.ts
+++ b/src/core/skills/characters/standard/qianxun.ts
@@ -63,8 +63,13 @@ export class QianXun extends TriggerSkill {
 @ShadowSkill
 @CommonSkill({ name: QianXun.GeneralName, description: QianXun.Description })
 export class QianXunShadow extends TriggerSkill implements OnDefineReleaseTiming {
-  afterLosingSkill(room: Room, playerId: PlayerId) {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   isAutoTrigger() {
@@ -72,7 +77,7 @@ export class QianXunShadow extends TriggerSkill implements OnDefineReleaseTiming
   }
 
   isTriggerable(event: ServerEventFinder<GameEventIdentifiers.PhaseChangeEvent>, stage?: AllStage) {
-    return stage === PhaseChangeStage.AfterPhaseChanged && event.to === PlayerPhase.PhaseFinish;
+    return stage === PhaseChangeStage.PhaseChanged && event.from === PlayerPhase.PhaseFinish;
   }
 
   canUse(room: Room, owner: Player, content: ServerEventFinder<GameEventIdentifiers.CardEffectEvent>) {

--- a/src/core/skills/characters/standard/qingjian.ts
+++ b/src/core/skills/characters/standard/qingjian.ts
@@ -99,8 +99,13 @@ export class QingJian extends TriggerSkill {
 @ShadowSkill
 @CommonSkill({ name: 'qingjian', description: 'qingjian_description' })
 export class QingJianShadow extends TriggerSkill implements OnDefineReleaseTiming {
-  afterLosingSkill(room: Room, playerId: PlayerId) {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   public isAutoTrigger() {

--- a/src/core/skills/characters/standard/qingnang.ts
+++ b/src/core/skills/characters/standard/qingnang.ts
@@ -84,12 +84,17 @@ export class QingNang extends ActiveSkill {
 @ShadowSkill
 @CompulsorySkill({ name: QingNang.GeneralName, description: QingNang.Description })
 export class QingNangShadow extends TriggerSkill implements OnDefineReleaseTiming {
-  afterLosingSkill(room: Room, playerId: PlayerId) {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   public isTriggerable(event: ServerEventFinder<GameEventIdentifiers.PhaseChangeEvent>, stage: AllStage): boolean {
-    return event.from === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.AfterPhaseChanged;
+    return event.from === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   public canUse(room: Room, owner: Player, event: ServerEventFinder<GameEventIdentifiers.PhaseChangeEvent>): boolean {

--- a/src/core/skills/characters/standard/tieji.ts
+++ b/src/core/skills/characters/standard/tieji.ts
@@ -30,7 +30,7 @@ export class TieJi extends TriggerSkill {
   async onEffect(room: Room, skillUseEvent: ServerEventFinder<GameEventIdentifiers.SkillEffectEvent>) {
     const { triggeredOnEvent } = skillUseEvent;
     const aimEvent = triggeredOnEvent as ServerEventFinder<GameEventIdentifiers.AimEvent>;
-    room.setFlag(aimEvent.toId, this.Name, true, true);
+    room.setFlag(aimEvent.toId, this.Name, true, this.Name);
     const to = room.getPlayerById(aimEvent.toId);
 
     const judge = await room.judge(skillUseEvent.fromId, undefined, this.Name);
@@ -68,11 +68,22 @@ export class TieJi extends TriggerSkill {
 @ShadowSkill
 @CompulsorySkill({ name: TieJi.GeneralName, description: TieJi.Description })
 export class TieJiShadow extends TriggerSkill implements OnDefineReleaseTiming {
-  afterLosingSkill(room: Room, playerId: PlayerId) {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
-  afterDead(room: Room, playerId: PlayerId) {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+
+  public afterDead(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   getPriority() {
@@ -80,7 +91,7 @@ export class TieJiShadow extends TriggerSkill implements OnDefineReleaseTiming {
   }
 
   public isTriggerable(event: ServerEventFinder<GameEventIdentifiers.PhaseChangeEvent>, stage: PhaseChangeStage) {
-    return stage === PhaseChangeStage.BeforePhaseChange && event.from === PlayerPhase.PhaseFinish;
+    return stage === PhaseChangeStage.PhaseChanged && event.from === PlayerPhase.PhaseFinish;
   }
 
   public isFlaggedSkill(room: Room, event: ServerEventFinder<GameEventIdentifiers.PhaseChangeEvent>, stage?: AllStage) {

--- a/src/core/skills/characters/standard/wusheng.ts
+++ b/src/core/skills/characters/standard/wusheng.ts
@@ -5,7 +5,7 @@ import { Slash } from 'core/cards/standard/slash';
 import { EventPacker, GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
 import { Sanguosha } from 'core/game/engine';
 import { INFINITE_DISTANCE } from 'core/game/game_props';
-import { PlayerPhase } from 'core/game/stage_processor';
+import { AllStage, PhaseChangeStage, PlayerPhase } from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
 import { PlayerId } from 'core/player/player_props';
 import { Room } from 'core/room/room';
@@ -62,11 +62,7 @@ export class WuSheng extends ViewAsSkill {
 
 @ShadowSkill
 @CompulsorySkill({ name: WuSheng.GeneralName, description: WuSheng.Description })
-export class WuShengShadow extends RulesBreakerSkill implements OnDefineReleaseTiming {
-  afterLosingSkill(room: Room, playerId: PlayerId) {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
-  }
-
+export class WuShengShadow extends RulesBreakerSkill {
   breakCardUsableDistance(cardId: CardId | CardMatcher, room: Room, owner: Player) {
     if (cardId instanceof CardMatcher) {
       return cardId.match(new CardMatcher({ generalName: ['slash'], suit: [CardSuit.Diamond] }))

--- a/src/core/skills/characters/standard/wusheng.ts
+++ b/src/core/skills/characters/standard/wusheng.ts
@@ -5,12 +5,9 @@ import { Slash } from 'core/cards/standard/slash';
 import { EventPacker, GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
 import { Sanguosha } from 'core/game/engine';
 import { INFINITE_DISTANCE } from 'core/game/game_props';
-import { AllStage, PhaseChangeStage, PlayerPhase } from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
-import { PlayerId } from 'core/player/player_props';
 import { Room } from 'core/room/room';
 import { CommonSkill, CompulsorySkill, RulesBreakerSkill, ShadowSkill, ViewAsSkill } from 'core/skills/skill';
-import { OnDefineReleaseTiming } from 'core/skills/skill_hooks';
 
 @CommonSkill({ name: 'wusheng', description: 'wusheng_description' })
 export class WuSheng extends ViewAsSkill {

--- a/src/core/skills/characters/standard/yijue.ts
+++ b/src/core/skills/characters/standard/yijue.ts
@@ -79,7 +79,7 @@ export class YiJue extends ActiveSkill {
     const card = Sanguosha.getCardById(selectedCards[0]);
     if (card.isBlack()) {
       await room.obtainSkill(to.Id, YiJueBlocker.Name);
-      room.setFlag(to.Id, this.Name, true, true);
+      room.setFlag(to.Id, this.Name, true, this.Name);
     } else {
       await room.moveCards({
         movingCards: selectedCards.map(card => ({ card, fromArea: CardMoveArea.HandArea })),
@@ -123,11 +123,22 @@ export class YiJue extends ActiveSkill {
 @ShadowSkill
 @CompulsorySkill({ name: YiJue.GeneralName, description: YiJue.Description })
 export class YiJueShadow extends TriggerSkill implements OnDefineReleaseTiming {
-  afterDead(room: Room) {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+  public afterDead(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
-  afterLosingSkill(room: Room, playerId: PlayerId) {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   public getPriority() {

--- a/src/core/skills/characters/standard/yijue.ts
+++ b/src/core/skills/characters/standard/yijue.ts
@@ -209,7 +209,7 @@ export class YiJueShadow extends TriggerSkill implements OnDefineReleaseTiming {
 }
 
 @ShadowSkill
-@CompulsorySkill({ name: 'yijueBlocker', description: 'yijueBlocker_description' })
+@CompulsorySkill({ name: 'shadowYijueBlocker', description: 'shadowYijueBlocker_description' })
 export class YiJueBlocker extends FilterSkill {
   canUseCard(cardId: CardId | CardMatcher, room: Room, owner: PlayerId) {
     return cardId instanceof CardMatcher

--- a/src/core/skills/characters/standard/zhaxiang.ts
+++ b/src/core/skills/characters/standard/zhaxiang.ts
@@ -3,7 +3,7 @@ import { CardId, CardSuit } from 'core/cards/libs/card_props';
 import { GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
 import { Sanguosha } from 'core/game/engine';
 import { INFINITE_DISTANCE } from 'core/game/game_props';
-import { AllStage, LoseHpStage, PlayerPhase } from 'core/game/stage_processor';
+import { AllStage, LoseHpStage, PhaseChangeStage, PlayerPhase } from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
 import { PlayerId } from 'core/player/player_props';
 import { Room } from 'core/room/room';
@@ -53,8 +53,13 @@ export class ZhaXiang extends TriggerSkill {
 @ShadowSkill
 @CompulsorySkill({ name: ZhaXiang.GeneralName, description: ZhaXiang.Description })
 export class ZhaXiangShadow extends TriggerSkill implements OnDefineReleaseTiming {
-  afterLosingSkill(room: Room, playerId: PlayerId) {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   public isTriggerable(event: ServerEventFinder<GameEventIdentifiers.AskForCardUseEvent>, stage: AllStage): boolean {

--- a/src/core/skills/characters/standard/zhiheng.ts
+++ b/src/core/skills/characters/standard/zhiheng.ts
@@ -1,5 +1,6 @@
 import { CardId } from 'core/cards/libs/card_props';
 import { CardMoveReason, GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
+import { PlayerPhase } from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
 import { PlayerCardsArea, PlayerId } from 'core/player/player_props';
 import { Room } from 'core/room/room';
@@ -10,6 +11,10 @@ import { ActiveSkill, CommonSkill } from 'core/skills/skill';
 export class ZhiHeng extends ActiveSkill {
   public canUse(room: Room, owner: Player): boolean {
     return !owner.hasUsedSkill(this.Name);
+  }
+
+  public isRefreshAt(room: Room, owner: Player, phase: PlayerPhase): boolean {
+    return phase === PlayerPhase.PlayCardStage;
   }
 
   public numberOfTargets(): number {

--- a/src/core/skills/characters/wind/guhuo.ts
+++ b/src/core/skills/characters/wind/guhuo.ts
@@ -205,7 +205,7 @@ export class GuHuoShadow extends TriggerSkill {
             await room.loseHp(response.fromId, 1);
           }
           await room.obtainSkill(response.fromId, ChanYuan.Name, true);
-          room.setFlag(response.fromId, ChanYuan.Name, true, true);
+          room.setFlag(response.fromId, ChanYuan.Name, true, ChanYuan.Name);
         }
       } else {
         if (response.selectedOption === 'guhuo:doubt') {

--- a/src/core/skills/characters/yijiang2011/pojun.ts
+++ b/src/core/skills/characters/yijiang2011/pojun.ts
@@ -5,11 +5,12 @@ import {
   AimStage,
   AllStage,
   DamageEffectStage,
+  PhaseChangeStage,
   PhaseStageChangeStage,
-  PlayerPhaseStages,
+  PlayerPhase,
 } from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
-import { PlayerCardsArea } from 'core/player/player_props';
+import { PlayerCardsArea, PlayerId } from 'core/player/player_props';
 import { Room } from 'core/room/room';
 import { Algorithm } from 'core/shares/libs/algorithm';
 import { TriggerSkill } from 'core/skills/skill';
@@ -158,12 +159,22 @@ export class PoJunClear extends TriggerSkill implements OnDefineReleaseTiming {
     }
   }
 
-  public afterLosingSkill(room: Room): boolean {
-    return room.CurrentPlayerStage === PlayerPhaseStages.PhaseFinish;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
-  public afterDead(room: Room): boolean {
-    return room.CurrentPlayerStage === PlayerPhaseStages.PhaseFinish;
+  public afterDead(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   public async whenDead(room: Room, player: Player): Promise<void> {
@@ -184,12 +195,8 @@ export class PoJunClear extends TriggerSkill implements OnDefineReleaseTiming {
     return true;
   }
 
-  public canUse(
-    room: Room,
-    owner: Player,
-    event: ServerEventFinder<GameEventIdentifiers.PhaseStageChangeEvent>,
-  ): boolean {
-    return event.toStage === PlayerPhaseStages.PhaseFinish;
+  public canUse(room: Room, owner: Player, event: ServerEventFinder<GameEventIdentifiers.PhaseChangeEvent>): boolean {
+    return event.from === PlayerPhase.PhaseFinish;
   }
 
   public async onTrigger(): Promise<boolean> {

--- a/src/core/skills/characters/yijiang2012/lihuo.ts
+++ b/src/core/skills/characters/yijiang2012/lihuo.ts
@@ -2,7 +2,7 @@ import { VirtualCard } from 'core/cards/card';
 import { FireSlash } from 'core/cards/legion_fight/fire_slash';
 import { EventPacker, GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
 import { Sanguosha } from 'core/game/engine';
-import { AllStage, CardUseStage, PlayerPhase } from 'core/game/stage_processor';
+import { AllStage, CardUseStage, PhaseChangeStage, PlayerPhase } from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
 import { PlayerId } from 'core/player/player_props';
 import { Room } from 'core/room/room';
@@ -146,8 +146,13 @@ export class LiHuoShadow extends TriggerSkill {
 @ShadowSkill
 @CommonSkill({ name: LiHuoShadow.Name, description: LiHuoShadow.Description })
 export class LiHuoLoseHp extends TriggerSkill implements OnDefineReleaseTiming {
-  public afterLosingSkill(room: Room, playerId: PlayerId) {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseBegin && stage === PhaseChangeStage.BeforePhaseChange;
   }
 
   public isAutoTrigger(): boolean {

--- a/src/core/skills/characters/yijiang2012/zishou.ts
+++ b/src/core/skills/characters/yijiang2012/zishou.ts
@@ -144,8 +144,13 @@ export class ZiShouReforge extends TriggerSkill {
 @ShadowSkill
 @CommonSkill({ name: ZiShouReforge.Name, description: ZiShouReforge.Description })
 export class ZiShouPrevent extends TriggerSkill implements OnDefineReleaseTiming {
-  public afterLosingSkill(room: Room): boolean {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   public isFlaggedSkill(): boolean {
@@ -193,8 +198,13 @@ export class ZiShouPrevent extends TriggerSkill implements OnDefineReleaseTiming
 @ShadowSkill
 @CommonSkill({ name: ZiShouPrevent.Name, description: ZiShouPrevent.Description })
 export class ZiShouShadow extends TriggerSkill implements OnDefineReleaseTiming {
-  public afterLosingSkill(room: Room): boolean {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   public isFlaggedSkill(): boolean {

--- a/src/core/skills/characters/yijiang2013/anjian.ts
+++ b/src/core/skills/characters/yijiang2013/anjian.ts
@@ -112,7 +112,7 @@ export class AnJian extends TriggerSkill {
       aimEvent.triggeredBySkills = aimEvent.triggeredBySkills
         ? [...aimEvent.triggeredBySkills, QingGangSkill.GeneralName]
         : [QingGangSkill.GeneralName];
-      room.setFlag(toId, this.GeneralName, true, true);
+      room.setFlag(toId, this.GeneralName, true, this.GeneralName);
     } else if (identifier === GameEventIdentifiers.DamageEvent) {
       const { fromId } = triggeredOnEvent as ServerEventFinder<GameEventIdentifiers.DamageEvent>;
       const damageEvent = triggeredOnEvent as ServerEventFinder<GameEventIdentifiers.DamageEvent>;

--- a/src/core/skills/characters/yijiang2013/jingce.ts
+++ b/src/core/skills/characters/yijiang2013/jingce.ts
@@ -109,8 +109,13 @@ export class JingCeRecorder extends TriggerSkill {
 @ShadowSkill
 @CommonSkill({ name: JingCeRecorder.Name, description: JingCeRecorder.Description })
 export class JingCeShadow extends TriggerSkill implements OnDefineReleaseTiming {
-  public afterLosingSkill(room: Room, playerId: PlayerId): boolean {
-    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   public isAutoTrigger(): boolean {
@@ -126,7 +131,7 @@ export class JingCeShadow extends TriggerSkill implements OnDefineReleaseTiming 
   }
 
   public canUse(room: Room, owner: Player, content: ServerEventFinder<GameEventIdentifiers.PhaseChangeEvent>): boolean {
-    return content.fromPlayer === owner.Id && content.to === PlayerPhase.PhaseFinish;
+    return content.fromPlayer === owner.Id && content.from === PlayerPhase.PhaseFinish;
   }
 
   public async onTrigger(): Promise<boolean> {

--- a/src/core/skills/characters/yijiang2013/zhuikong.ts
+++ b/src/core/skills/characters/yijiang2013/zhuikong.ts
@@ -1,8 +1,15 @@
 import { CardMatcher } from 'core/cards/libs/card_matcher';
 import { CardId } from 'core/cards/libs/card_props';
 import { GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
-import { AllStage, PhaseStageChangeStage, PlayerPhase, PlayerPhaseStages } from 'core/game/stage_processor';
+import {
+  AllStage,
+  PhaseChangeStage,
+  PhaseStageChangeStage,
+  PlayerPhase,
+  PlayerPhaseStages,
+} from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
+import { PlayerId } from 'core/player/player_props';
 import { Room } from 'core/room/room';
 import { GlobalFilterSkill, GlobalRulesBreakerSkill, OnDefineReleaseTiming, TriggerSkill } from 'core/skills/skill';
 import { CommonSkill, PersistentSkill, ShadowSkill } from 'core/skills/skill_wrappers';
@@ -12,8 +19,13 @@ export class ZhuiKong extends TriggerSkill implements OnDefineReleaseTiming {
   public static Filter: string = 'qiuyuan_filter';
   public static DistanceBreak: string = 'distance_break';
 
-  public afterLosingSkill(room: Room): boolean {
-    return room.CurrentPlayerPhase === PlayerPhase.FinishStage;
+  public afterLosingSkill(
+    room: Room,
+    owner: PlayerId,
+    content: ServerEventFinder<GameEventIdentifiers>,
+    stage?: AllStage,
+  ): boolean {
+    return room.CurrentPlayerPhase === PlayerPhase.PhaseFinish && stage === PhaseChangeStage.PhaseChanged;
   }
 
   public isRefreshAt(room: Room, owner: Player, phase: PlayerPhase): boolean {

--- a/src/core/skills/characters/yijiang2014/shibei.ts
+++ b/src/core/skills/characters/yijiang2014/shibei.ts
@@ -18,7 +18,7 @@ export class ShiBei extends TriggerSkill {
 
   async whenObtainingSkill(room: Room, owner: Player) {
     if (room.Analytics.getDamagedRecord(owner.Id, true).length > 0) {
-      room.setFlag(owner.Id, this.GeneralName, true, true);
+      room.setFlag(owner.Id, this.GeneralName, true, this.GeneralName);
     }
   }
 
@@ -42,7 +42,7 @@ export class ShiBei extends TriggerSkill {
 
   public async onEffect(room: Room, event: ServerEventFinder<GameEventIdentifiers.SkillEffectEvent>): Promise<boolean> {
     if (room.getFlag<boolean>(event.fromId, this.GeneralName) !== true) {
-      room.setFlag(event.fromId, this.GeneralName, true, true);
+      room.setFlag(event.fromId, this.GeneralName, true, this.GeneralName);
     }
 
     if (room.Analytics.getDamagedRecord(event.fromId, true).length <= 1) {

--- a/src/core/skills/skill.ts
+++ b/src/core/skills/skill.ts
@@ -371,7 +371,7 @@ export abstract class ActiveSkill extends Skill {
   }
 
   public isRefreshAt(room: Room, owner: Player, phase: PlayerPhase) {
-    return phase === PlayerPhase.PhaseBegin;
+    return phase === PlayerPhase.PlayCardStage;
   }
 }
 

--- a/src/core/skills/skill_hooks.ts
+++ b/src/core/skills/skill_hooks.ts
@@ -1,11 +1,13 @@
+import { GameEventIdentifiers, ServerEventFinder } from 'core/event/event';
+import { AllStage } from 'core/game/stage_processor';
 import { Player } from 'core/player/player';
 import { PlayerId } from 'core/player/player_props';
 import { Room } from 'core/room/room';
 import { Skill } from './skill';
 
 export interface OnDefineReleaseTiming {
-  afterLosingSkill?(room: Room, playerId: PlayerId): boolean;
-  afterDead?(room: Room, playerId: PlayerId): boolean;
+  afterLosingSkill?(room: Room, playerId: PlayerId, content: ServerEventFinder<GameEventIdentifiers>, stage?: AllStage): boolean;
+  afterDead?(room: Room, playerId: PlayerId, content: ServerEventFinder<GameEventIdentifiers>, stage?: AllStage): boolean;
   whenObtainingSkill?(room: Room, player: Player): Promise<void>;
   whenLosingSkill?(room: Room, player: Player): Promise<void>;
   whenDead?(room: Room, player: Player): Promise<void>;

--- a/src/ui/platforms/desktop/src/pages/room/game_processor.tsx
+++ b/src/ui/platforms/desktop/src/pages/room/game_processor.tsx
@@ -345,7 +345,7 @@ export class GameClientProcessor {
     type: T,
     content: ServerEventFinder<T>,
   ) {
-    this.store.room.getPlayerById(content.to).setFlag(content.name, content.value, content.invisible);
+    this.store.room.getPlayerById(content.to).setFlag(content.name, content.value, content.tagName);
   }
   protected async onHandleRemoveFlagEvent<T extends GameEventIdentifiers.RemoveFlagEvent>(
     type: T,


### PR DESCRIPTION
①`room.setFlag(player: PlayerId, name: string, value: T, invisible?: boolean) -> room.setFlag(player: PlayerId, name: string, value: T, tagName?: string)`
tagName为自定义的flag名称，如为undefined则不显示此flag。

②为钩子上的afterLosingSkill及afterDead增加了当前事件和事件阶段，用于精确脱钩。

③修改了不合理的脱钩时机。

